### PR TITLE
feat: Add admin moderation routes and components

### DIFF
--- a/src/components/common/ModerationHistoryTable.tsx
+++ b/src/components/common/ModerationHistoryTable.tsx
@@ -1,0 +1,96 @@
+import { Avatar, Badge, Group, Stack, Text, Timeline } from "@mantine/core";
+import { IconCheck, IconLock, IconLockOpen, IconX } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import type { CensorLog } from "../../interfaces/Story";
+import { format } from "../../lib/format";
+import { AdminCensorService } from "../../services/AdminCensorService";
+import { AdminChapterCensorService } from "../../services/AdminChapterCensorService";
+
+interface Props {
+  targetType: "Story" | "Chapter";
+  targetId: string;
+}
+
+const actionMeta = {
+  approve: {
+    label: "Phê duyệt",
+    color: "green",
+    Icon: IconCheck,
+  },
+  reject: {
+    label: "Từ chối",
+    color: "red",
+    Icon: IconX,
+  },
+  ban: {
+    label: "Khóa",
+    color: "orange",
+    Icon: IconLock,
+  },
+  unban: {
+    label: "Mở khóa",
+    color: "teal",
+    Icon: IconLockOpen,
+  },
+} as const;
+
+export function ModerationHistoryTable({ targetType, targetId }: Props) {
+  const { data: logs, isLoading } = useQuery<CensorLog[]>({
+    queryKey: ["censor-logs", targetType, targetId],
+    queryFn: () =>
+      targetType === "Story"
+        ? AdminCensorService.getStoryCensorLog(targetId)
+        : AdminChapterCensorService.getChapterCensorLog(targetId),
+  });
+
+  if (isLoading) return <Text size="sm">Đang tải lịch sử...</Text>;
+  if (!logs || logs.length === 0)
+    return (
+      <Text size="sm" c="dimmed">
+        Chưa có lịch sử kiểm duyệt.
+      </Text>
+    );
+
+  return (
+    <Timeline active={logs.length} bulletSize={28} lineWidth={2}>
+      {logs.map((log) => {
+        const action = actionMeta[log.action] ?? actionMeta.approve;
+        const Icon = action.Icon;
+        return (
+          <Timeline.Item
+            key={log._id}
+            bullet={<Icon size={14} />}
+            color={action.color}
+            title={
+              <Group gap="xs" align="center">
+                <Text fw={600} size="sm">
+                  {action.label}
+                </Text>
+                <Badge size="xs" color={action.color} variant="light">
+                  {log.action}
+                </Badge>
+              </Group>
+            }
+          >
+            <Stack gap={4} mt={4}>
+              <Group gap="xs">
+                <Avatar src={log.adminId.avatar} size="xs" radius="xl" />
+                <Text size="xs" fw={500}>
+                  {log.adminId.fullName}
+                </Text>
+              </Group>
+              {log.reason && (
+                <Text size="sm" c="dimmed">
+                  Lý do: {log.reason}
+                </Text>
+              )}
+              <Text size="xs" c="dimmed">
+                {format.date(new Date(log.createdAt))}
+              </Text>
+            </Stack>
+          </Timeline.Item>
+        );
+      })}
+    </Timeline>
+  );
+}

--- a/src/components/data-table/content.tsx
+++ b/src/components/data-table/content.tsx
@@ -1,114 +1,120 @@
 import { Group, Skeleton, Table } from "@mantine/core";
 import {
-	IconArrowDown,
-	IconArrowsSort,
-	IconArrowUp,
+  IconArrowDown,
+  IconArrowsSort,
+  IconArrowUp,
 } from "@tabler/icons-react";
 import { flexRender } from "@tanstack/react-table";
 import { useDataTableContext } from "./provider";
 
 type DataTableContentProps = {
-	className?: string;
+  className?: string;
 };
 
 export function DataTableContent<TData>({ className }: DataTableContentProps) {
-	const { table, loading: isLoading } = useDataTableContext<TData>();
-	const columns = table.getAllColumns();
+  const { table, loading: isLoading } = useDataTableContext<TData>();
+  const columns = table.getAllColumns();
 
-	return (
-		<Table.ScrollContainer
-			minWidth={500}
-			scrollAreaProps={{ offsetScrollbars: "present" }}
-			style={{
-				border: "1px solid var(--mantine-color-default-border)",
-				borderRadius: "var(--mantine-radius-md)",
-			}}
-			className={className}
-		>
-			<Table stickyHeader striped withColumnBorders>
-				<Table.Thead>
-					{table.getHeaderGroups().map((headerGroup) => (
-						<Table.Tr key={headerGroup.id} h={"3rem"} c={"blue"}>
-							{headerGroup.headers.map(({ id, column, getContext }) => {
-								const canSort = column.getCanSort();
-								const sortDirection = column.getIsSorted();
+  return (
+    <Table.ScrollContainer
+      minWidth={500}
+      scrollAreaProps={{ offsetScrollbars: "present" }}
+      style={{
+        border: "1px solid var(--mantine-color-default-border)",
+        borderRadius: "var(--mantine-radius-md)",
+      }}
+      className={className}
+    >
+      <Table stickyHeader striped withColumnBorders>
+        <Table.Thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <Table.Tr
+              key={headerGroup.id}
+              h={"3rem"}
+              c={
+                "light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-4))"
+              }
+            >
+              {headerGroup.headers.map(({ id, column, getContext }) => {
+                const canSort = column.getCanSort();
+                const sortDirection = column.getIsSorted();
 
-								return (
-									<Table.Th
-										key={id}
-										onClick={() => canSort && column.toggleSorting()}
-										className={canSort ? "cursor-pointer" : undefined}
-									>
-										<Group
-											gap="xs"
-											wrap="nowrap"
-											justify="space-between"
-											style={{ width: "100%" }}
-										>
-											{flexRender(column.columnDef.header, getContext())}
-											{canSort && (
-												<span
-													style={{
-														display: "inline-flex",
-														alignItems: "center",
-														flexShrink: 0,
-													}}
-												>
-													{sortDirection === "asc" ? (
-														<IconArrowUp size={16} />
-													) : sortDirection === "desc" ? (
-														<IconArrowDown size={16} />
-													) : (
-														<IconArrowsSort
-															size={16}
-															style={{ opacity: 0.3 }}
-														/>
-													)}
-												</span>
-											)}
-										</Group>
-									</Table.Th>
-								);
-							})}
-						</Table.Tr>
-					))}
-				</Table.Thead>
+                return (
+                  <Table.Th
+                    key={id}
+                    onClick={() => canSort && column.toggleSorting()}
+                    className={canSort ? "cursor-pointer" : undefined}
+                  >
+                    <Group
+                      gap="xs"
+                      wrap="nowrap"
+                      justify="space-between"
+                      style={{ width: "100%" }}
+                    >
+                      {flexRender(column.columnDef.header, getContext())}
+                      {canSort && (
+                        <span
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            flexShrink: 0,
+                          }}
+                        >
+                          {sortDirection === "asc" ? (
+                            <IconArrowUp size={16} />
+                          ) : sortDirection === "desc" ? (
+                            <IconArrowDown size={16} />
+                          ) : (
+                            <IconArrowsSort
+                              size={16}
+                              style={{ opacity: 0.3 }}
+                            />
+                          )}
+                        </span>
+                      )}
+                    </Group>
+                  </Table.Th>
+                );
+              })}
+            </Table.Tr>
+          ))}
+        </Table.Thead>
 
-				<Table.Tbody>
-					{isLoading ? (
-						Array.from({ length: 10 }).map((_, index) => (
-							<Table.Tr key={index} style={{ minHeight: "4rem" }}>
-								<Table.Td colSpan={columns.length}>
-									<Skeleton height={16} radius={"xl"} width={"100%"} />
-								</Table.Td>
-							</Table.Tr>
-						))
-					) : table.getRowModel().rows?.length ? (
-						table.getRowModel().rows.map((row) => (
-							<Table.Tr
-								key={row.id}
-								data-state={row.getIsSelected() && "selected"}
-								h={"3rem"}
-								bg={
-									row.getIsSelected()
-										? "var(--mantine-color-blue-light)"
-										: undefined
-								}
-							>
-								{row.getVisibleCells().map((cell) => (
-									<Table.Td key={cell.id}>
-										{flexRender(cell.column.columnDef.cell, cell.getContext())}
-									</Table.Td>
-								))}
-							</Table.Tr>
-						))
-					) : (
-						<Table.Tr key={"data-table-empty"} style={{ minHeight: "56px" }}>
-							<Table.Td colSpan={columns.length}>No results.</Table.Td>
-						</Table.Tr>
-					)}
-				</Table.Tbody>
-			</Table>
-		</Table.ScrollContainer>
-	);
+        <Table.Tbody>
+          {isLoading ? (
+            Array.from({ length: 10 }).map((_, index) => (
+              <Table.Tr key={index} style={{ minHeight: "4rem" }}>
+                <Table.Td colSpan={columns.length}>
+                  <Skeleton height={16} radius={"xl"} width={"100%"} />
+                </Table.Td>
+              </Table.Tr>
+            ))
+          ) : table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <Table.Tr
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                h={"3rem"}
+                bg={
+                  row.getIsSelected()
+                    ? "var(--mantine-color-blue-light)"
+                    : undefined
+                }
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <Table.Td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Table.Td>
+                ))}
+              </Table.Tr>
+            ))
+          ) : (
+            <Table.Tr key={"data-table-empty"} style={{ minHeight: "56px" }}>
+              <Table.Td colSpan={columns.length}>No results.</Table.Td>
+            </Table.Tr>
+          )}
+        </Table.Tbody>
+      </Table>
+    </Table.ScrollContainer>
+  );
 }

--- a/src/hooks/useAdminCensor.ts
+++ b/src/hooks/useAdminCensor.ts
@@ -1,0 +1,122 @@
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import { AdminCensorService } from "../services/AdminCensorService";
+
+interface ErrorResponse {
+  message: string;
+}
+
+export const useApproveStory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => AdminCensorService.approveStory(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã duyệt truyện thành công",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Có lỗi xảy ra khi duyệt truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useRejectStory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      AdminCensorService.rejectStory(id, reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã từ chối truyện thành công",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Có lỗi xảy ra khi từ chối truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useBanStory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      AdminCensorService.banStory(id, reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã khóa truyện thành công",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Có lỗi xảy ra khi khóa truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useUnbanStory = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => AdminCensorService.unbanStory(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "stories", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã mở khóa truyện thành công",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<ErrorResponse>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Có lỗi xảy ra khi mở khóa truyện",
+        color: "red",
+      });
+    },
+  });
+};

--- a/src/hooks/useAdminChapterCensor.ts
+++ b/src/hooks/useAdminChapterCensor.ts
@@ -1,0 +1,123 @@
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import { AdminChapterCensorService } from "../services/AdminChapterCensorService";
+
+interface ModerationAction {
+  id: string;
+  reason?: string;
+}
+
+export const useApproveChapter = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => AdminChapterCensorService.approveChapter(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã phê duyệt chương truyện",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<any>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Không thể phê duyệt chương truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useRejectChapter = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: ModerationAction) =>
+      AdminChapterCensorService.rejectChapter(id, reason || ""),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã từ chối chương truyện",
+        color: "blue",
+      });
+    },
+    onError: (error: AxiosError<any>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Không thể từ chối chương truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useBanChapter = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, reason }: ModerationAction) =>
+      AdminChapterCensorService.banChapter(id, reason || ""),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã khóa chương truyện",
+        color: "orange",
+      });
+    },
+    onError: (error: AxiosError<any>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Không thể khóa chương truyện",
+        color: "red",
+      });
+    },
+  });
+};
+
+export const useUnbanChapter = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => AdminChapterCensorService.unbanChapter(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "pending"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "chapters", "managed"],
+      });
+      notifications.show({
+        title: "Thành công",
+        message: "Đã mở khóa chương truyện",
+        color: "green",
+      });
+    },
+    onError: (error: AxiosError<any>) => {
+      notifications.show({
+        title: "Lỗi",
+        message:
+          error.response?.data?.message || "Không thể mở khóa chương truyện",
+        color: "red",
+      });
+    },
+  });
+};

--- a/src/interfaces/Story.ts
+++ b/src/interfaces/Story.ts
@@ -1,34 +1,50 @@
 // src/interfaces/Story.ts
 export interface Story {
-	id: string;
-	title: string;
-	slug: string;
-	description?: string;
-	image: string;
-	author?: {
-		id: string;
-		name: string;
-		penName: string;
-	}; // object thông tin tác giả// có thể được định nghĩa rõ hơn nếu cần
-	topics: string[];
-	tags?: string[];
-	status?: string;
-	isFinish?: boolean | string;
-	isPremium: boolean;
-	views: number;
-	stars?: number;
-	followers: number;
-	rates?: number;
-	chapters?: number;
-	createdAt?: string;
-	updatedAt?: string;
+  _id: string;
+  title: string;
+  slug: string;
+  image: string;
+  description: string;
+  authorId: {
+    _id: string;
+    username: string;
+    email: string;
+    avatar?: string;
+    fullName: string;
+  };
+  topics: string[];
+  tags: string[];
+  status: "draft" | "pending" | "active" | "rejected" | "private" | "banned";
+  isPremium: boolean;
+  isFinish: boolean;
+  views: number;
+  stars: number;
+  rates: number;
+  followers: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface StoryItem {
-	id: string;
-	title: string;
-	slug: string;
-	image: string;
-	views: number;
-	chapterNumber: number;
+  id: string;
+  title: string;
+  slug: string;
+  image: string;
+  views: number;
+  chapterNumber: number;
+}
+
+export interface CensorLog {
+  _id: string;
+  storyId: string;
+  adminId: {
+    _id: string;
+    username: string;
+    email: string;
+    avatar?: string;
+    fullName: string;
+  };
+  action: "approve" | "reject" | "ban" | "unban";
+  reason?: string;
+  createdAt: string;
 }

--- a/src/layouts/admin/navbar/NavbarItems.tsx
+++ b/src/layouts/admin/navbar/NavbarItems.tsx
@@ -1,44 +1,41 @@
 import {
-	IconFlag,
-	IconGauge,
-	IconListCheck,
-	IconNotes,
-	type IconProps,
-	IconUsers,
+  IconGauge,
+  IconListCheck,
+  IconNotes,
+  type IconProps,
+  IconUsers,
 } from "@tabler/icons-react";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
 
 export type NavbarItem = {
-	label: string;
-	icon?: ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
-	link?: string;
-	links?: NavbarItem[];
+  label: string;
+  icon?: ForwardRefExoticComponent<IconProps & RefAttributes<SVGSVGElement>>;
+  link?: string;
+  links?: NavbarItem[];
 };
 
 export const NAVBAR_ITEMS: NavbarItem[] = [
-	{
-		label: "Trang chủ",
-		icon: IconGauge,
-		link: "/admin/dashboard",
-	},
-	{
-		label: "Thể loại Truyện",
-		icon: IconNotes,
-		link: "/admin/catalog/genre",
-	},
-	{
-		label: "Quản trị viên",
-		icon: IconUsers,
-		link: "/admin/account",
-	},
-	{
-		label: "Kiểm duyệt nội dung",
-		icon: IconListCheck,
-		link: "/admin/censor",
-	},
-	{
-		label: "Báo cáo vi phạm",
-		icon: IconFlag,
-		link: "/admin/users",
-	},
+  {
+    label: "Trang chủ",
+    icon: IconGauge,
+    link: "/admin/dashboard",
+  },
+  {
+    label: "Thể loại Truyện",
+    icon: IconNotes,
+    link: "/admin/catalog/genre",
+  },
+  {
+    label: "Quản trị viên",
+    icon: IconUsers,
+    link: "/admin/account",
+  },
+  {
+    label: "Kiểm duyệt nội dung",
+    icon: IconListCheck,
+    links: [
+      { label: "Kiểm duyệt Truyện", link: "/admin/censor/stories" },
+      { label: "Kiểm duyệt Chương", link: "/admin/censor/chapters" },
+    ],
+  },
 ];

--- a/src/pages/admin/censor/AdminChapterModeration.tsx
+++ b/src/pages/admin/censor/AdminChapterModeration.tsx
@@ -1,0 +1,502 @@
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Tabs,
+  Text,
+  Textarea,
+  Title,
+} from "@mantine/core";
+import { useDisclosure, useFullscreen } from "@mantine/hooks";
+import { modals } from "@mantine/modals";
+import {
+  IconArrowsMaximize,
+  IconArrowsMinimize,
+  IconCheck,
+  IconClockHour4,
+  IconHistory,
+  IconX,
+} from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
+import { ModerationHistoryTable } from "../../../components/common/ModerationHistoryTable";
+import {
+  DataTable,
+  DataTableColumns,
+  DataTableContent,
+  DataTableFilter,
+  DataTablePagination,
+  useDataTable,
+} from "../../../components/data-table";
+import {
+  useApproveChapter,
+  useRejectChapter,
+} from "../../../hooks/useAdminChapterCensor";
+import { format } from "../../../lib/format";
+import {
+  AdminChapterCensorService,
+  type Chapter,
+} from "../../../services/AdminChapterCensorService";
+
+// ── Chapter Content Fullscreen Modal ──────────────────────────────────────────
+function ChapterContentFullscreenModal({
+  chapter,
+  opened,
+  onClose,
+  onApprove,
+  onReject,
+}: {
+  chapter: Chapter | null;
+  opened: boolean;
+  onClose: () => void;
+  onApprove: (ch: Chapter) => void;
+  onReject: (ch: Chapter) => void;
+}) {
+  const { ref, toggle, fullscreen } = useFullscreen();
+
+  // fetch content from contentURL — must be called unconditionally (Rules of Hooks)
+  const { data: content, isLoading } = useQuery({
+    queryKey: ["admin", "chapter-content", chapter?._id],
+    queryFn: async () => {
+      if (!chapter) return "";
+      const r = await fetch(chapter.contentURL);
+      return r.text();
+    },
+    enabled: opened && !!chapter,
+  });
+
+  if (!chapter) return null;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Group gap="sm">
+          <Text fw={700}>
+            Chương {chapter.chapterNumber}: {chapter.title}
+          </Text>
+          <Badge
+            size="sm"
+            color={chapter.status === "pending" ? "yellow" : "gray"}
+            variant="light"
+          >
+            {chapter.status}
+          </Badge>
+        </Group>
+      }
+      size="90%"
+      styles={{
+        body: { padding: 0 },
+        header: {
+          padding: "12px 16px",
+          borderBottom: "1px solid var(--mantine-color-default-border)",
+        },
+      }}
+    >
+      {/* Toolbar */}
+      <Group
+        px="md"
+        py="xs"
+        justify="space-between"
+        style={{
+          borderBottom: "1px solid var(--mantine-color-default-border)",
+        }}
+      >
+        {chapter.status === "pending" ? (
+          <Group gap="xs">
+            <Button
+              color="green"
+              size="sm"
+              leftSection={<IconCheck size={14} />}
+              onClick={() => {
+                onClose();
+                onApprove(chapter);
+              }}
+            >
+              Phê duyệt
+            </Button>
+            <Button
+              variant="light"
+              color="red"
+              size="sm"
+              leftSection={<IconX size={14} />}
+              onClick={() => {
+                onClose();
+                onReject(chapter);
+              }}
+            >
+              Từ chối
+            </Button>
+          </Group>
+        ) : (
+          <Text size="sm" c="dimmed">
+            Chương đã được xử lý
+          </Text>
+        )}
+        <ActionIcon
+          variant="subtle"
+          size="lg"
+          onClick={toggle}
+          title={fullscreen ? "Thu nhỏ" : "Toàn màn hình"}
+        >
+          {fullscreen ? (
+            <IconArrowsMinimize size={18} />
+          ) : (
+            <IconArrowsMaximize size={18} />
+          )}
+        </ActionIcon>
+      </Group>
+
+      {/* Content */}
+      <Box ref={ref} style={{ background: "var(--mantine-color-body)" }}>
+        <ScrollArea h={500} px="xl" py="lg">
+          {isLoading ? (
+            <Text c="dimmed">Đang tải nội dung chương...</Text>
+          ) : (
+            <Box
+              style={{
+                maxWidth: 720,
+                margin: "0 auto",
+                lineHeight: 1.8,
+                fontSize: 16,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {content || <Text c="dimmed">Không có nội dung.</Text>}
+            </Box>
+          )}
+        </ScrollArea>
+      </Box>
+    </Modal>
+  );
+}
+
+// ── Pending Chapters Tab ───────────────────────────────────────────────────────
+function PendingChaptersTab() {
+  const { mutate: approveChapter } = useApproveChapter();
+  const { mutate: rejectChapter } = useRejectChapter();
+  const [selectedChapter, setSelectedChapter] = useState<Chapter | null>(null);
+  const [chapterOpened, { open: openChapter, close: closeChapter }] =
+    useDisclosure(false);
+
+  const handleApprove = (chapter: Chapter) => {
+    modals.openConfirmModal({
+      title: "Phê duyệt chương",
+      children: (
+        <Text size="sm">
+          Phê duyệt Chương {chapter.chapterNumber}:{" "}
+          <Text span fw={600}>
+            "{chapter.title}"
+          </Text>
+          ?
+        </Text>
+      ),
+      labels: { confirm: "Phê duyệt", cancel: "Hủy" },
+      confirmProps: { color: "green" },
+      onConfirm: () => approveChapter(chapter._id),
+    });
+  };
+
+  const handleReject = (chapter: Chapter) => {
+    let reason = "";
+    modals.openConfirmModal({
+      title: "Từ chối chương",
+      children: (
+        <Stack gap="sm">
+          <Text size="sm">
+            Nhập lý do từ chối Chương {chapter.chapterNumber}:{" "}
+            <Text span fw={600}>
+              "{chapter.title}"
+            </Text>
+            :
+          </Text>
+          <Textarea
+            placeholder="Lý do từ chối..."
+            onChange={(e) => {
+              reason = e.target.value;
+            }}
+            required
+          />
+        </Stack>
+      ),
+      labels: { confirm: "Từ chối", cancel: "Hủy" },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        if (!reason.trim()) return;
+        rejectChapter({ id: chapter._id, reason });
+      },
+    });
+  };
+
+  const dataTable = useDataTable<Chapter>({
+    columns: getPendingChapterColumns(
+      (ch) => {
+        setSelectedChapter(ch);
+        openChapter();
+      },
+      handleApprove,
+      handleReject
+    ),
+    service: AdminChapterCensorService.getPendingChapters,
+    queryKey: ["admin", "chapters", "pending"],
+  });
+
+  return (
+    <>
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+
+      <ChapterContentFullscreenModal
+        chapter={selectedChapter}
+        opened={chapterOpened}
+        onClose={closeChapter}
+        onApprove={handleApprove}
+        onReject={handleReject}
+      />
+    </>
+  );
+}
+
+// ── History Chapters Tab ───────────────────────────────────────────────────────
+function HistoryChaptersTab() {
+  const [selectedChapter, setSelectedChapter] = useState<Chapter | null>(null);
+  const [historyOpened, { open: openHistory, close: closeHistory }] =
+    useDisclosure(false);
+
+  const dataTable = useDataTable<Chapter>({
+    columns: getHistoryChapterColumns((ch) => {
+      setSelectedChapter(ch);
+      openHistory();
+    }),
+    service: AdminChapterCensorService.getManagedChapters,
+    queryKey: ["admin", "chapters", "managed"],
+  });
+
+  return (
+    <>
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+
+      <Modal
+        opened={historyOpened}
+        onClose={closeHistory}
+        title={
+          <Text fw={700}>
+            Lịch sử: Chương {selectedChapter?.chapterNumber} —{" "}
+            {selectedChapter?.title}
+          </Text>
+        }
+        size="lg"
+      >
+        {selectedChapter && (
+          <ModerationHistoryTable
+            targetType="Chapter"
+            targetId={selectedChapter._id}
+          />
+        )}
+      </Modal>
+    </>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────────
+export function AdminChapterModeration() {
+  return (
+    <div className="space-y-4">
+      <Group justify="space-between" align="center">
+        <Title order={2}>Kiểm duyệt Chương</Title>
+      </Group>
+
+      <Tabs defaultValue="pending">
+        <Tabs.List>
+          <Tabs.Tab value="pending" leftSection={<IconClockHour4 size={16} />}>
+            Chờ phê duyệt
+          </Tabs.Tab>
+          <Tabs.Tab value="history" leftSection={<IconHistory size={16} />}>
+            Lịch sử phê duyệt
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="pending" pt="md">
+          <PendingChaptersTab />
+        </Tabs.Panel>
+
+        <Tabs.Panel value="history" pt="md">
+          <HistoryChaptersTab />
+        </Tabs.Panel>
+      </Tabs>
+    </div>
+  );
+}
+
+// ── Column definitions ─────────────────────────────────────────────────────────
+function getPendingChapterColumns(
+  onRead: (ch: Chapter) => void,
+  onApprove: (ch: Chapter) => void,
+  onReject: (ch: Chapter) => void
+): ColumnDef<Chapter>[] {
+  return [
+    {
+      accessorKey: "chapterNumber",
+      header: "Chương",
+      cell: ({ row }) => <Text fw={600}>#{row.original.chapterNumber}</Text>,
+    },
+    {
+      accessorKey: "title",
+      header: "Tiêu đề",
+      cell: ({ row }) => <Text size="sm">{row.original.title}</Text>,
+    },
+    {
+      id: "story",
+      header: "Thuộc truyện",
+      cell: ({ row }) => {
+        const story = row.original.storyId as
+          | { _id: string; title: string; image?: string }
+          | string
+          | undefined;
+        if (!story || typeof story === "string")
+          return (
+            <Text size="sm" c="dimmed">
+              —
+            </Text>
+          );
+        return (
+          <Group gap="xs">
+            <Avatar src={story.image} size="sm" radius="sm" />
+            <Text size="sm">{story.title}</Text>
+          </Group>
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Ngày gửi",
+      cell: ({ row }) => format.date(new Date(row.original.createdAt ?? "")),
+    },
+    {
+      id: "actions",
+      header: "Hành động",
+      cell: ({ row }) => (
+        <Group gap="xs" justify="center">
+          <Button
+            variant="subtle"
+            size="xs"
+            onClick={() => onRead(row.original)}
+          >
+            Đọc nội dung
+          </Button>
+          <Button
+            variant="light"
+            color="green"
+            size="xs"
+            leftSection={<IconCheck size={14} />}
+            onClick={() => onApprove(row.original)}
+          >
+            Duyệt
+          </Button>
+          <Button
+            variant="light"
+            color="red"
+            size="xs"
+            leftSection={<IconX size={14} />}
+            onClick={() => onReject(row.original)}
+          >
+            Từ chối
+          </Button>
+        </Group>
+      ),
+    },
+  ];
+}
+
+function getHistoryChapterColumns(
+  onHistory: (ch: Chapter) => void
+): ColumnDef<Chapter>[] {
+  return [
+    {
+      accessorKey: "chapterNumber",
+      header: "Chương",
+      cell: ({ row }) => <Text fw={600}>#{row.original.chapterNumber}</Text>,
+    },
+    {
+      accessorKey: "title",
+      header: "Tiêu đề",
+      cell: ({ row }) => <Text size="sm">{row.original.title}</Text>,
+    },
+    {
+      id: "story",
+      header: "Thuộc truyện",
+      cell: ({ row }) => {
+        const story = row.original.storyId as
+          | { _id: string; title: string }
+          | string
+          | undefined;
+        if (!story || typeof story === "string")
+          return (
+            <Text size="sm" c="dimmed">
+              —
+            </Text>
+          );
+        return <Text size="sm">{story.title}</Text>;
+      },
+    },
+    {
+      accessorKey: "status",
+      header: "Trạng thái",
+      cell: ({ row }) => {
+        const s = row.original.status;
+        return (
+          <Badge
+            size="xs"
+            color={
+              s === "active"
+                ? "green"
+                : s === "rejected"
+                ? "red"
+                : s === "banned"
+                ? "orange"
+                : "gray"
+            }
+            variant="light"
+          >
+            {s}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Lịch sử",
+      cell: ({ row }) => (
+        <Button
+          variant="subtle"
+          size="xs"
+          leftSection={<IconHistory size={14} />}
+          onClick={() => onHistory(row.original)}
+        >
+          Xem lịch sử
+        </Button>
+      ),
+    },
+  ];
+}

--- a/src/pages/admin/censor/AdminManagedStories.tsx
+++ b/src/pages/admin/censor/AdminManagedStories.tsx
@@ -1,0 +1,282 @@
+import {
+  ActionIcon,
+  Avatar,
+  Badge,
+  Button,
+  Group,
+  Stack,
+  Text,
+  Textarea,
+  Timeline,
+  Title,
+} from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { IconHistory, IconLock, IconLockOpen } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  DataTable,
+  DataTableColumns,
+  DataTableContent,
+  DataTableFilter,
+  DataTablePagination,
+  useDataTable,
+} from "../../../components/data-table";
+import { useBanStory, useUnbanStory } from "../../../hooks/useAdminCensor";
+import type { Story } from "../../../interfaces/Story";
+import { format } from "../../../lib/format";
+import { AdminCensorService } from "../../../services/AdminCensorService";
+
+export function AdminManagedStories() {
+  const { mutate: banStory } = useBanStory();
+  const { mutate: unbanStory } = useUnbanStory();
+
+  const handleBan = (story: Story) => {
+    let reason = "";
+    modals.openConfirmModal({
+      title: "Khóa truyện",
+      children: (
+        <div className="space-y-4">
+          <Text size="sm">
+            Vui lòng nhập lý do khóa truyện{" "}
+            <Text span fw={600}>
+              "{story.title}"
+            </Text>
+          </Text>
+          <Textarea
+            placeholder="Nhập lý do vi phạm..."
+            onChange={(e) => {
+              reason = e.target.value;
+            }}
+            required
+          />
+        </div>
+      ),
+      labels: { confirm: "Khóa", cancel: "Hủy" },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        if (!reason.trim()) {
+          return;
+        }
+        banStory({ id: story._id, reason });
+      },
+    });
+  };
+
+  const handleUnban = (story: Story) => {
+    modals.openConfirmModal({
+      title: "Mở khóa truyện",
+      children: (
+        <Text size="sm">
+          Bạn có chắc chắn muốn mở khóa truyện{" "}
+          <Text span fw={600}>
+            "{story.title}"
+          </Text>
+          ?
+        </Text>
+      ),
+      labels: { confirm: "Mở khóa", cancel: "Hủy" },
+      confirmProps: { color: "green" },
+      onConfirm: () => {
+        unbanStory(story._id);
+      },
+    });
+  };
+
+  const handleShowHistory = (story: Story) => {
+    modals.open({
+      title: `Lịch sử kiểm duyệt: ${story.title}`,
+      size: "lg",
+      children: <CensorHistory storyId={story._id} />,
+    });
+  };
+
+  const dataTable = useDataTable<Story>({
+    columns: getColumns(handleBan, handleUnban, handleShowHistory),
+    service: AdminCensorService.getManagedStories,
+    queryKey: ["managed-stories"],
+  });
+
+  return (
+    <div className="space-y-4">
+      <Group justify="space-between" align="center">
+        <Title order={2}>Quản lý vi phạm</Title>
+      </Group>
+
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+    </div>
+  );
+}
+
+function CensorHistory({ storyId }: { storyId: string }) {
+  const { data: logs, isLoading } = useQuery({
+    queryKey: ["story-censor-logs", storyId],
+    queryFn: () => AdminCensorService.getStoryCensorLog(storyId),
+  });
+
+  if (isLoading) return <Text>Đang tải...</Text>;
+  if (!logs || logs.length === 0)
+    return <Text>Chưa có lịch sử kiểm duyệt.</Text>;
+
+  return (
+    <Timeline active={logs.length} bulletSize={24} lineWidth={2}>
+      {logs.map((log) => (
+        <Timeline.Item
+          key={log._id}
+          bullet={
+            log.action === "approve" ? (
+              <IconLockOpen size={12} />
+            ) : log.action === "ban" || log.action === "reject" ? (
+              <IconLock size={12} />
+            ) : (
+              <IconLockOpen size={12} />
+            )
+          }
+          title={
+            <Group gap="xs">
+              <Text fw={700} size="sm">
+                {log.action === "approve"
+                  ? "Duyệt truyện"
+                  : log.action === "reject"
+                  ? "Từ chối duyệt"
+                  : log.action === "ban"
+                  ? "Khóa truyện"
+                  : "Mở khóa truyện"}
+              </Text>
+              <Badge
+                size="xs"
+                color={
+                  log.action === "approve" || log.action === "unban"
+                    ? "green"
+                    : "red"
+                }
+              >
+                {log.action}
+              </Badge>
+            </Group>
+          }
+        >
+          <Stack gap={4} mt={4}>
+            <Group gap="xs">
+              <Avatar src={log.adminId.avatar} size="xs" radius="xl" />
+              <Text size="xs" fw={500}>
+                {log.adminId.fullName}
+              </Text>
+            </Group>
+            {log.reason && (
+              <Text size="sm" c="dimmed">
+                Lý do: {log.reason}
+              </Text>
+            )}
+            <Text size="xs" c="dimmed">
+              {format.date(new Date(log.createdAt))}
+            </Text>
+          </Stack>
+        </Timeline.Item>
+      ))}
+    </Timeline>
+  );
+}
+
+function getColumns(
+  onBan: (story: Story) => void,
+  onUnban: (story: Story) => void,
+  onHistory: (story: Story) => void
+): ColumnDef<Story>[] {
+  return [
+    {
+      accessorKey: "image",
+      header: "Ảnh bìa",
+      cell: ({ row }) => (
+        <Avatar
+          src={row.original.image}
+          alt={row.original.title}
+          radius="sm"
+          size="lg"
+        />
+      ),
+    },
+    {
+      accessorKey: "title",
+      header: "Tên truyện",
+      cell: ({ row }) => <Text fw={500}>{row.original.title}</Text>,
+    },
+    {
+      accessorKey: "authorId",
+      header: "Tác giả",
+      cell: ({ row }) => (
+        <Group gap="xs">
+          <Avatar
+            src={row.original.authorId.avatar}
+            size={"sm"}
+            radius={"xl"}
+          />
+          <div className="flex flex-col">
+            <Text size="sm" fw={500}>
+              {row.original.authorId.fullName}
+            </Text>
+            <Text size="xs" c="dimmed">
+              @{row.original.authorId.username}
+            </Text>
+          </div>
+        </Group>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Trạng thái",
+      cell: ({ row }) => {
+        const status = row.original.status;
+        return (
+          <Badge color={status === "active" ? "green" : "red"} variant="filled">
+            {status === "active" ? "Hoạt động" : "Bị khóa"}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Hành động",
+      cell: ({ row }) => (
+        <div className="flex items-center justify-center gap-2">
+          {row.original.status === "active" ? (
+            <Button
+              variant="light"
+              color="red"
+              size="xs"
+              leftSection={<IconLock size={14} />}
+              onClick={() => onBan(row.original)}
+            >
+              Khóa
+            </Button>
+          ) : (
+            <Button
+              variant="light"
+              color="green"
+              size="xs"
+              leftSection={<IconLockOpen size={14} />}
+              onClick={() => onUnban(row.original)}
+            >
+              Mở khóa
+            </Button>
+          )}
+          <ActionIcon
+            variant="subtle"
+            color="blue"
+            onClick={() => onHistory(row.original)}
+            title="Lịch sử kiểm duyệt"
+          >
+            <IconHistory size={18} />
+          </ActionIcon>
+        </div>
+      ),
+    },
+  ];
+}

--- a/src/pages/admin/censor/AdminPendingStories.tsx
+++ b/src/pages/admin/censor/AdminPendingStories.tsx
@@ -1,0 +1,190 @@
+import {
+  Avatar,
+  Badge,
+  Button,
+  Group,
+  Text,
+  Textarea,
+  Title,
+} from "@mantine/core";
+import { modals } from "@mantine/modals";
+import { IconCheck, IconX } from "@tabler/icons-react";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  DataTable,
+  DataTableColumns,
+  DataTableContent,
+  DataTablePagination,
+  useDataTable,
+} from "../../../components/data-table";
+import { DataTableFilter } from "../../../components/data-table/filter";
+import { useApproveStory, useRejectStory } from "../../../hooks/useAdminCensor";
+import type { Story } from "../../../interfaces/Story";
+import { format } from "../../../lib/format";
+import { AdminCensorService } from "../../../services/AdminCensorService";
+
+export function AdminPendingStories() {
+  const { mutate: approveStory } = useApproveStory();
+  const { mutate: rejectStory } = useRejectStory();
+
+  const handleApprove = (story: Story) => {
+    modals.openConfirmModal({
+      title: "Xác nhận duyệt",
+      children: (
+        <Text size="sm">
+          Bạn có chắc chắn muốn duyệt truyện{" "}
+          <Text span fw={600}>
+            "{story.title}"
+          </Text>
+          ? Truyện sẽ được hiển thị công khai trên hệ thống.
+        </Text>
+      ),
+      labels: { confirm: "Duyệt", cancel: "Hủy" },
+      confirmProps: { color: "green" },
+      onConfirm: () => {
+        approveStory(story._id);
+      },
+    });
+  };
+
+  const handleReject = (story: Story) => {
+    let reason = "";
+    modals.openConfirmModal({
+      title: "Từ chối duyệt truyện",
+      children: (
+        <div className="space-y-4">
+          <Text size="sm">
+            Vui lòng nhập lý do từ chối truyện{" "}
+            <Text span fw={600}>
+              "{story.title}"
+            </Text>
+          </Text>
+          <Textarea
+            placeholder="Nhập lý do vi phạm..."
+            onChange={(e) => {
+              reason = e.target.value;
+            }}
+            required
+          />
+        </div>
+      ),
+      labels: { confirm: "Từ chối", cancel: "Hủy" },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        if (!reason.trim()) {
+          return;
+        }
+        rejectStory({ id: story._id, reason });
+      },
+    });
+  };
+
+  const dataTable = useDataTable<Story>({
+    columns: getColumns(handleApprove, handleReject),
+    service: AdminCensorService.getPendingStories,
+    queryKey: ["pending-stories"],
+  });
+
+  return (
+    <div className="space-y-4">
+      <Group justify="space-between" align="center">
+        <Title order={2}>Duyệt truyện mới</Title>
+      </Group>
+
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+    </div>
+  );
+}
+
+function getColumns(
+  onApprove: (story: Story) => void,
+  onReject: (story: Story) => void
+): ColumnDef<Story>[] {
+  return [
+    {
+      accessorKey: "image",
+      header: "Ảnh bìa",
+      cell: ({ row }) => (
+        <Avatar
+          src={row.original.image}
+          alt={row.original.title}
+          radius="sm"
+          size="lg"
+        />
+      ),
+    },
+    {
+      accessorKey: "title",
+      header: "Tên truyện",
+      cell: ({ row }) => <Text fw={500}>{row.original.title}</Text>,
+    },
+    {
+      accessorKey: "authorId",
+      header: "Tác giả",
+      cell: ({ row }) => (
+        <Group gap="xs">
+          <Avatar
+            src={row.original.authorId.avatar}
+            size={"sm"}
+            radius={"xl"}
+          />
+          <div className="flex flex-col">
+            <Text size="sm" fw={500}>
+              {row.original.authorId.fullName}
+            </Text>
+            <Text size="xs" c="dimmed">
+              @{row.original.authorId.username}
+            </Text>
+          </div>
+        </Group>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Trạng thái",
+      cell: () => (
+        <Badge color="yellow" variant="filled">
+          Chờ duyệt
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Ngày gửi",
+      cell: ({ row }) => format.date(new Date(row.original.createdAt)),
+    },
+    {
+      id: "actions",
+      header: "Hành động",
+      cell: ({ row }) => (
+        <div className="flex items-center justify-center gap-2">
+          <Button
+            variant="light"
+            color="green"
+            size="xs"
+            leftSection={<IconCheck size={14} />}
+            onClick={() => onApprove(row.original)}
+          >
+            Duyệt
+          </Button>
+          <Button
+            variant="light"
+            color="red"
+            size="xs"
+            leftSection={<IconX size={14} />}
+            onClick={() => onReject(row.original)}
+          >
+            Từ chối
+          </Button>
+        </div>
+      ),
+    },
+  ];
+}

--- a/src/pages/admin/censor/AdminStoryModeration.tsx
+++ b/src/pages/admin/censor/AdminStoryModeration.tsx
@@ -1,0 +1,546 @@
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Divider,
+  Group,
+  Image,
+  Modal,
+  ScrollArea,
+  Stack,
+  Table,
+  Tabs,
+  Text,
+  Textarea,
+  Title,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { modals } from "@mantine/modals";
+import {
+  IconBook,
+  IconCheck,
+  IconClockHour4,
+  IconHistory,
+  IconInfoCircle,
+  IconX,
+} from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
+import { ModerationHistoryTable } from "../../../components/common/ModerationHistoryTable";
+import {
+  DataTable,
+  DataTableColumns,
+  DataTableContent,
+  DataTableFilter,
+  DataTablePagination,
+  useDataTable,
+} from "../../../components/data-table";
+import { useApproveStory, useRejectStory } from "../../../hooks/useAdminCensor";
+import type { Story } from "../../../interfaces/Story";
+import { format } from "../../../lib/format";
+import { AdminCensorService } from "../../../services/AdminCensorService";
+
+// ── Story Detail Modal ─────────────────────────────────────────────────────────
+function StoryDetailModal({
+  story,
+  opened,
+  onClose,
+  onApprove,
+  onReject,
+}: {
+  story: Story | null;
+  opened: boolean;
+  onClose: () => void;
+  onApprove: (story: Story) => void;
+  onReject: (story: Story) => void;
+}) {
+  const { data: chapters, isLoading } = useQuery({
+    queryKey: ["admin", "story-chapters", story?._id],
+    queryFn: () => AdminCensorService.getStoryChapters(story!._id),
+    enabled: !!story,
+  });
+
+  if (!story) return null;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Text fw={700} size="lg">
+          {story.title}
+        </Text>
+      }
+      size="xl"
+      scrollAreaComponent={ScrollArea.Autosize}
+    >
+      <Stack gap="lg">
+        {/* Story Info */}
+        <Group align="flex-start" gap="md">
+          <Image
+            src={story.image}
+            alt={story.title}
+            w={120}
+            radius="md"
+            fallbackSrc="https://placehold.co/120x160?text=Ảnh"
+          />
+          <Stack gap={6} style={{ flex: 1 }}>
+            <Text size="sm" c="dimmed">
+              Tác giả
+            </Text>
+            <Group gap="xs">
+              <Avatar src={story.authorId.avatar} size="sm" radius="xl" />
+              <div>
+                <Text size="sm" fw={500}>
+                  {story.authorId.fullName}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  @{story.authorId.username}
+                </Text>
+              </div>
+            </Group>
+            <Text size="sm" c="dimmed" mt={4}>
+              Thể loại
+            </Text>
+            <Group gap={4}>
+              {story.topics.map((t) => (
+                <Badge key={t} size="xs" variant="light">
+                  {t}
+                </Badge>
+              ))}
+            </Group>
+            <Text size="sm" c="dimmed" mt={4}>
+              Ngày gửi
+            </Text>
+            <Text size="sm">{format.date(new Date(story.createdAt))}</Text>
+          </Stack>
+        </Group>
+
+        <Box>
+          <Text size="sm" fw={600} mb={4}>
+            Mô tả
+          </Text>
+          <Text size="sm" c="dimmed">
+            {story.description || "Không có mô tả."}
+          </Text>
+        </Box>
+
+        <Divider
+          label={
+            <Group gap={4}>
+              <IconBook size={14} />
+              <Text size="xs">
+                Danh sách chương ({isLoading ? "..." : (chapters?.length ?? 0)})
+              </Text>
+            </Group>
+          }
+        />
+
+        {isLoading ? (
+          <Text size="sm">Đang tải danh sách chương...</Text>
+        ) : (
+          <Table striped highlightOnHover withTableBorder>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Chương</Table.Th>
+                <Table.Th>Tiêu đề</Table.Th>
+                <Table.Th>Trạng thái</Table.Th>
+                <Table.Th>Ngày tạo</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {chapters && chapters.length > 0 ? (
+                chapters.map(
+                  (ch: {
+                    _id: string;
+                    chapterNumber: number;
+                    title: string;
+                    status: string;
+                    createdAt?: string;
+                  }) => (
+                    <Table.Tr key={ch._id}>
+                      <Table.Td>#{ch.chapterNumber}</Table.Td>
+                      <Table.Td>{ch.title}</Table.Td>
+                      <Table.Td>
+                        <Badge
+                          size="xs"
+                          color={
+                            ch.status === "active"
+                              ? "green"
+                              : ch.status === "pending"
+                                ? "yellow"
+                                : ch.status === "rejected"
+                                  ? "red"
+                                  : "gray"
+                          }
+                          variant="light"
+                        >
+                          {ch.status}
+                        </Badge>
+                      </Table.Td>
+                      <Table.Td>
+                        {format.date(new Date(ch.createdAt as string))}
+                      </Table.Td>
+                    </Table.Tr>
+                  ),
+                )
+              ) : (
+                <Table.Tr>
+                  <Table.Td colSpan={4}>
+                    <Text size="sm" c="dimmed" ta="center">
+                      Chưa có chương nào.
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              )}
+            </Table.Tbody>
+          </Table>
+        )}
+
+        <Divider />
+
+        {/* Actions */}
+        {story.status === "pending" && (
+          <Group justify="flex-end" gap="sm">
+            <Button
+              variant="light"
+              color="red"
+              leftSection={<IconX size={14} />}
+              onClick={() => {
+                onClose();
+                onReject(story);
+              }}
+            >
+              Từ chối
+            </Button>
+            <Button
+              color="green"
+              leftSection={<IconCheck size={14} />}
+              onClick={() => {
+                onClose();
+                onApprove(story);
+              }}
+            >
+              Phê duyệt
+            </Button>
+          </Group>
+        )}
+      </Stack>
+    </Modal>
+  );
+}
+
+// ── Pending Tab ────────────────────────────────────────────────────────────────
+function PendingStoriesTab() {
+  const { mutate: approveStory } = useApproveStory();
+  const { mutate: rejectStory } = useRejectStory();
+  const [selectedStory, setSelectedStory] = useState<Story | null>(null);
+  const [detailOpened, { open: openDetail, close: closeDetail }] =
+    useDisclosure(false);
+
+  const handleApprove = (story: Story) => {
+    modals.openConfirmModal({
+      title: "Xác nhận duyệt truyện",
+      children: (
+        <Text size="sm">
+          Bạn có chắc chắn muốn phê duyệt truyện{" "}
+          <Text span fw={600}>
+            "{story.title}"
+          </Text>
+          ?
+        </Text>
+      ),
+      labels: { confirm: "Duyệt", cancel: "Hủy" },
+      confirmProps: { color: "green" },
+      onConfirm: () => approveStory(story._id),
+    });
+  };
+
+  const handleReject = (story: Story) => {
+    let reason = "";
+    modals.openConfirmModal({
+      title: "Từ chối duyệt truyện",
+      children: (
+        <div className="space-y-4">
+          <Text size="sm">
+            Nhập lý do từ chối{" "}
+            <Text span fw={600}>
+              "{story.title}"
+            </Text>
+            :
+          </Text>
+          <Textarea
+            placeholder="Nhập lý do..."
+            onChange={(e) => {
+              reason = e.target.value;
+            }}
+            required
+          />
+        </div>
+      ),
+      labels: { confirm: "Từ chối", cancel: "Hủy" },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        if (!reason.trim()) return;
+        rejectStory({ id: story._id, reason });
+      },
+    });
+  };
+
+  const handleViewDetail = (story: Story) => {
+    setSelectedStory(story);
+    openDetail();
+  };
+
+  const dataTable = useDataTable<Story>({
+    columns: getPendingColumns(handleApprove, handleReject, handleViewDetail),
+    service: AdminCensorService.getPendingStories,
+    queryKey: ["admin", "stories", "pending"],
+  });
+
+  return (
+    <>
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+
+      <StoryDetailModal
+        story={selectedStory}
+        opened={detailOpened}
+        onClose={closeDetail}
+        onApprove={handleApprove}
+        onReject={handleReject}
+      />
+    </>
+  );
+}
+
+// ── History Tab ────────────────────────────────────────────────────────────────
+function HistoryStoriesTab() {
+  const [selectedStory, setSelectedStory] = useState<Story | null>(null);
+  const [historyOpened, { open: openHistory, close: closeHistory }] =
+    useDisclosure(false);
+
+  const dataTable = useDataTable<Story>({
+    columns: getHistoryColumns((story) => {
+      setSelectedStory(story);
+      openHistory();
+    }),
+    service: AdminCensorService.getManagedStories,
+    queryKey: ["admin", "stories", "managed"],
+  });
+
+  return (
+    <>
+      <DataTable dataTable={dataTable}>
+        <div className="flex items-center justify-between gap-4">
+          <DataTableFilter />
+          <DataTableColumns />
+        </div>
+        <DataTableContent />
+        <DataTablePagination />
+      </DataTable>
+
+      <Modal
+        opened={historyOpened}
+        onClose={closeHistory}
+        title={<Text fw={700}>Lịch sử kiểm duyệt: {selectedStory?.title}</Text>}
+        size="lg"
+      >
+        {selectedStory && (
+          <ModerationHistoryTable
+            targetType="Story"
+            targetId={selectedStory._id}
+          />
+        )}
+      </Modal>
+    </>
+  );
+}
+
+// ── Main Page ──────────────────────────────────────────────────────────────────
+export function AdminStoryModeration() {
+  return (
+    <div className="space-y-4">
+      <Group justify="space-between" align="center">
+        <Title order={2}>Kiểm duyệt Truyện</Title>
+      </Group>
+
+      <Tabs defaultValue="pending">
+        <Tabs.List>
+          <Tabs.Tab value="pending" leftSection={<IconClockHour4 size={16} />}>
+            Chờ phê duyệt
+          </Tabs.Tab>
+          <Tabs.Tab value="history" leftSection={<IconHistory size={16} />}>
+            Lịch sử phê duyệt
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="pending" pt="md">
+          <PendingStoriesTab />
+        </Tabs.Panel>
+
+        <Tabs.Panel value="history" pt="md">
+          <HistoryStoriesTab />
+        </Tabs.Panel>
+      </Tabs>
+    </div>
+  );
+}
+
+// ── Column definitions ─────────────────────────────────────────────────────────
+function getPendingColumns(
+  onApprove: (s: Story) => void,
+  onReject: (s: Story) => void,
+  onDetail: (s: Story) => void,
+): ColumnDef<Story>[] {
+  return [
+    {
+      accessorKey: "image",
+      header: "Ảnh",
+      cell: ({ row }) => (
+        <Avatar
+          src={row.original.image}
+          alt={row.original.title}
+          radius="sm"
+          size="lg"
+        />
+      ),
+    },
+    {
+      accessorKey: "title",
+      header: "Tên truyện",
+      cell: ({ row }) => <Text fw={500}>{row.original.title}</Text>,
+    },
+    {
+      accessorKey: "authorId",
+      header: "Tác giả",
+      cell: ({ row }) => (
+        <Group gap="xs">
+          <Avatar src={row.original.authorId.avatar} size="sm" radius="xl" />
+          <div>
+            <Text size="sm" fw={500}>
+              {row.original.authorId.fullName}
+            </Text>
+            <Text size="xs" c="dimmed">
+              @{row.original.authorId.username}
+            </Text>
+          </div>
+        </Group>
+      ),
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Ngày gửi",
+      cell: ({ row }) => format.date(new Date(row.original.createdAt)),
+    },
+    {
+      id: "actions",
+      header: "Hành động",
+      cell: ({ row }) => (
+        <Group gap="xs" justify="center">
+          <Button
+            variant="subtle"
+            size="xs"
+            leftSection={<IconInfoCircle size={14} />}
+            onClick={() => onDetail(row.original)}
+          >
+            Chi tiết
+          </Button>
+          <Button
+            variant="light"
+            color="green"
+            size="xs"
+            leftSection={<IconCheck size={14} />}
+            onClick={() => onApprove(row.original)}
+          >
+            Duyệt
+          </Button>
+          <Button
+            variant="light"
+            color="red"
+            size="xs"
+            leftSection={<IconX size={14} />}
+            onClick={() => onReject(row.original)}
+          >
+            Từ chối
+          </Button>
+        </Group>
+      ),
+    },
+  ];
+}
+
+function getHistoryColumns(onHistory: (s: Story) => void): ColumnDef<Story>[] {
+  return [
+    {
+      accessorKey: "image",
+      header: "Ảnh",
+      cell: ({ row }) => (
+        <Avatar
+          src={row.original.image}
+          alt={row.original.title}
+          radius="sm"
+          size="lg"
+        />
+      ),
+    },
+    {
+      accessorKey: "title",
+      header: "Tên truyện",
+      cell: ({ row }) => <Text fw={500}>{row.original.title}</Text>,
+    },
+    {
+      accessorKey: "authorId",
+      header: "Tác giả",
+      cell: ({ row }) => (
+        <Group gap="xs">
+          <Avatar src={row.original.authorId.avatar} size="sm" radius="xl" />
+          <Text size="sm">{row.original.authorId.fullName}</Text>
+        </Group>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Trạng thái",
+      cell: ({ row }) => {
+        const s = row.original.status;
+        return (
+          <Badge
+            color={
+              s === "active" ? "green" : s === "rejected" ? "red" : "orange"
+            }
+            variant="light"
+          >
+            {s === "active"
+              ? "Hoạt động"
+              : s === "rejected"
+                ? "Đã từ chối"
+                : "Bị khóa"}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Lịch sử",
+      cell: ({ row }) => (
+        <Button
+          variant="subtle"
+          size="xs"
+          leftSection={<IconHistory size={14} />}
+          onClick={() => onHistory(row.original)}
+        >
+          Xem lịch sử
+        </Button>
+      ),
+    },
+  ];
+}

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -3,41 +3,61 @@ import { Navigate, Outlet, type RouteObject } from "react-router-dom";
 import { AdminLayout } from "../../layouts/admin";
 import { AdminAccountManagement } from "../../pages/admin/account/AdminAccountManagement";
 import { GenreManagement } from "../../pages/admin/catalog/genre/GenreManagement";
+import { AdminChapterModeration } from "../../pages/admin/censor/AdminChapterModeration";
+import { AdminStoryModeration } from "../../pages/admin/censor/AdminStoryModeration";
 import NotFoundPage from "../../pages/error/not-found";
 
 export const AdminRoute: RouteObject = {
-	path: "/admin",
-	element: (
-		// <AdminRouteGuard>
-		<AdminLayout />
-		// </AdminRouteGuard>
-	),
-	children: [
-		{
-			index: true,
-			element: <Navigate to="dashboard" replace />,
-		},
-		{
-			path: "dashboard",
-			element: <div>Dashboard</div>,
-		},
-		{
-			path: "account",
-			element: <AdminAccountManagement />,
-		},
-		{
-			path: "catalog",
-			element: <Outlet />,
-			children: [
-				{
-					path: "genre",
-					element: <GenreManagement />,
-				},
-			],
-		},
-		{
-			path: "*",
-			element: <NotFoundPage />,
-		},
-	],
+  path: "/admin",
+  element: (
+    // <AdminRouteGuard>
+    <AdminLayout />
+    // </AdminRouteGuard>
+  ),
+  children: [
+    {
+      index: true,
+      element: <Navigate to="dashboard" replace />,
+    },
+    {
+      path: "dashboard",
+      element: <div>Dashboard</div>,
+    },
+    {
+      path: "account",
+      element: <AdminAccountManagement />,
+    },
+    {
+      path: "catalog",
+      element: <Outlet />,
+      children: [
+        {
+          path: "genre",
+          element: <GenreManagement />,
+        },
+      ],
+    },
+    {
+      path: "censor",
+      element: <Outlet />,
+      children: [
+        {
+          index: true,
+          element: <Navigate to="stories" replace />,
+        },
+        {
+          path: "stories",
+          element: <AdminStoryModeration />,
+        },
+        {
+          path: "chapters",
+          element: <AdminChapterModeration />,
+        },
+      ],
+    },
+    {
+      path: "*",
+      element: <NotFoundPage />,
+    },
+  ],
 };

--- a/src/services/AdminCensorService.ts
+++ b/src/services/AdminCensorService.ts
@@ -1,0 +1,47 @@
+import { type CensorLog, type Story } from "../interfaces/Story";
+import { instance as axios } from "../lib/axios";
+import { type Chapter } from "./AdminChapterCensorService";
+
+export const AdminCensorService = {
+  getPendingStories: async (): Promise<Story[]> => {
+    const response = await axios.get("/admin/stories/pending");
+    return response.data.data;
+  },
+
+  getManagedStories: async (): Promise<Story[]> => {
+    const response = await axios.get("/admin/stories/managed");
+    return response.data.data;
+  },
+
+  approveStory: async (id: string): Promise<Story> => {
+    const response = await axios.post(`/admin/stories/${id}/approve`);
+    return response.data.data;
+  },
+
+  rejectStory: async (id: string, reason: string): Promise<Story> => {
+    const response = await axios.post(`/admin/stories/${id}/reject`, {
+      reason,
+    });
+    return response.data.data;
+  },
+
+  banStory: async (id: string, reason: string): Promise<Story> => {
+    const response = await axios.post(`/admin/stories/${id}/ban`, { reason });
+    return response.data.data;
+  },
+
+  unbanStory: async (id: string): Promise<Story> => {
+    const response = await axios.post(`/admin/stories/${id}/unban`);
+    return response.data.data;
+  },
+
+  getStoryCensorLog: async (id: string): Promise<CensorLog[]> => {
+    const response = await axios.get(`/admin/stories/${id}/logs`);
+    return response.data.data;
+  },
+
+  getStoryChapters: async (id: string): Promise<Chapter[]> => {
+    const response = await axios.get(`/admin/stories/${id}/chapters`);
+    return response.data.data;
+  },
+};

--- a/src/services/AdminChapterCensorService.ts
+++ b/src/services/AdminChapterCensorService.ts
@@ -1,0 +1,53 @@
+import type { CensorLog } from "../interfaces/Story";
+import { instance as axios } from "../lib/axios";
+
+// Mở rộng interface Story cho các phần cần thiết
+export interface Chapter {
+  _id: string;
+  storyId: string | any;
+  chapterNumber: number;
+  title: string;
+  contentURL: string;
+  status: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export const AdminChapterCensorService = {
+  getPendingChapters: async (): Promise<Chapter[]> => {
+    const response = await axios.get("/admin/chapters/pending");
+    return response.data.data;
+  },
+
+  getManagedChapters: async (): Promise<Chapter[]> => {
+    const response = await axios.get("/admin/chapters/managed");
+    return response.data.data;
+  },
+
+  approveChapter: async (id: string): Promise<Chapter> => {
+    const response = await axios.post(`/admin/chapters/${id}/approve`);
+    return response.data.data;
+  },
+
+  rejectChapter: async (id: string, reason: string): Promise<Chapter> => {
+    const response = await axios.post(`/admin/chapters/${id}/reject`, {
+      reason,
+    });
+    return response.data.data;
+  },
+
+  banChapter: async (id: string, reason: string): Promise<Chapter> => {
+    const response = await axios.post(`/admin/chapters/${id}/ban`, { reason });
+    return response.data.data;
+  },
+
+  unbanChapter: async (id: string): Promise<Chapter> => {
+    const response = await axios.post(`/admin/chapters/${id}/unban`);
+    return response.data.data;
+  },
+
+  getChapterCensorLog: async (id: string): Promise<CensorLog[]> => {
+    const response = await axios.get(`/admin/chapters/${id}/logs`);
+    return response.data.data;
+  },
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,30 +1,30 @@
 import { createTheme } from "@mantine/core";
 
 export const appTheme = createTheme({
-	fontFamily: "'Montserrat', 'Inter', sans-serif",
-	headings: {
-		fontFamily: "'Montserrat', 'Inter', sans-serif",
-		fontWeight: "600",
-	},
-	primaryColor: "blue",
-	defaultRadius: "md",
-	fontSizes: {
-		sm: "14px",
-		md: "16px",
-		lg: "18px",
-	},
-	colors: {
-		dark: [
-			"#ffffff", // mantine lấy màu mặc định của text là dark 1
-			"#0d0d0d",
-			"#1a1a1a",
-			"#262626",
-			"#333333",
-			"#404040",
-			"#4d4d4d",
-			"#595959", // của background là dark 7
-			"#666666",
-			"#737373",
-		],
-	},
+  fontFamily: "'Montserrat', 'Inter', sans-serif",
+  headings: {
+    fontFamily: "'Montserrat', 'Inter', sans-serif",
+    fontWeight: "600",
+  },
+  primaryColor: "blue",
+  defaultRadius: "md",
+  fontSizes: {
+    sm: "14px",
+    md: "16px",
+    lg: "18px",
+  },
+  colors: {
+    dark: [
+      "#ffffff", // 0: primary text (màu chữ chính)
+      "#f3f4f6", // 1: light text
+      "#9ca3af", // 2: secondary text (màu text table head)
+      "#6b7280", // 3: placeholder, disabled text (cải thiện tương phản cho disabled và ô tìm kiếm)
+      "#4b5563", // 4: border mặc định (làm cho border sidebar, header, select, checkbox nổi bật hơn)
+      "#374151", // 5: hover state
+      "#1f2937", // 6: component background (datatable, cards)
+      "#111827", // 7: app background mặc định của mantine
+      "#0f172a", // 8: dark background (dùng trong AdminLayout)
+      "#020617", // 9: darkest
+    ],
+  },
 });


### PR DESCRIPTION
Introduces new pages for managing story and chapter moderation within the admin panel. This includes:

- New pages for pending stories (`AdminPendingStories.tsx`), managed stories (`AdminManagedStories.tsx`), pending chapters (`AdminChapterModeration.tsx`), and history (`AdminChapterModeration.tsx`).
- Integration with data table components for displaying and interacting with moderation data.
- Hooks for handling moderation actions (approve, reject, ban, unban) for both stories and chapters.
- Updates to the navigation bar to include moderation links.
- New service methods for fetching and manipulating moderation data.
- Refined color palette in the theme for better UI contrast.