### PR TITLE
Add password reset pages and API service

### DIFF
--- a/src/pages/forgot-password/ForgotPassword.module.css
+++ b/src/pages/forgot-password/ForgotPassword.module.css
@@ -1,0 +1,18 @@
+.title {
+  font-size: 26px;
+  font-weight: 500;
+  font-family: Outfit, var(--mantine-font-family);
+}
+
+.controls {
+  @media (max-width: var(--mantine-breakpoint-xs)) {
+    flex-direction: column-reverse;
+  }
+}
+
+.control {
+  @media (max-width: var(--mantine-breakpoint-xs)) {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/pages/forgot-password/ForgotPasswordPage.tsx
+++ b/src/pages/forgot-password/ForgotPasswordPage.tsx
@@ -1,0 +1,248 @@
+import { IconArrowLeft, IconMail } from "@tabler/icons-react";
+import {
+  Anchor,
+  Box,
+  Button,
+  Center,
+  Container,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  TextInput,
+  ThemeIcon,
+  Title,
+} from "@mantine/core";
+import classes from "./ForgotPassword.module.css";
+import { useForm } from "@mantine/form";
+import z from "zod";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { notifications } from "@mantine/notifications";
+import UserService from "../../services/UserService";
+
+const forgotPasswordSchema = z.object({
+  email: z.email("Định dạng email không hợp lệ"),
+});
+
+type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
+
+type Status = "idle" | "loading" | "waiting" | "error";
+
+export default function ForgotPasswordPage() {
+  const navigate = useNavigate();
+  const [status, setStatus] = useState<Status>("idle");
+  const [email, setEmail] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [resendLoading, setResendLoading] = useState(false);
+
+  const form = useForm<ForgotPasswordFormValues>({
+    initialValues: {
+      email: "",
+    },
+    validate: zod4Resolver(forgotPasswordSchema),
+  });
+
+  // Cooldown timer effect
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+
+    const timer = setInterval(() => {
+      setResendCooldown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [resendCooldown]);
+
+  const handleSubmit = async (values: ForgotPasswordFormValues) => {
+    setStatus("loading");
+    setErrorMessage(null);
+
+    try {
+      const response = await UserService.requestPasswordReset(values.email);
+
+      setEmail(values.email);
+      setStatus("waiting");
+
+      // Set cooldown from response
+      if (response.nextResendIn) {
+        setResendCooldown(response.nextResendIn);
+      }
+
+      notifications.show({
+        title: "Thành công",
+        message:
+          response.message ||
+          "Nếu email tồn tại, bạn sẽ nhận được liên kết đặt lại mật khẩu.",
+        color: "green",
+        autoClose: 3000,
+      });
+    } catch (err: unknown) {
+      let errorMsg = "Yêu cầu thất bại. Vui lòng thử lại.";
+
+      if (typeof err === "object" && err !== null && "message" in err) {
+        errorMsg = (err as { message: string }).message;
+      } else if (typeof err === "string") {
+        errorMsg = err;
+      }
+
+      setErrorMessage(errorMsg);
+      setStatus("error");
+
+      notifications.show({
+        title: "Lỗi",
+        message: errorMsg,
+        color: "red",
+        autoClose: 3000,
+      });
+    }
+  };
+
+  const handleResendEmail = async () => {
+    if (!email.trim()) {
+      notifications.show({
+        title: "Lỗi",
+        message: "Vui lòng nhập địa chỉ email.",
+        color: "orange",
+        autoClose: 3000,
+      });
+      return;
+    }
+
+    setResendLoading(true);
+    try {
+      const response = await UserService.requestPasswordReset(email);
+
+      // Set cooldown timer from response
+      if (response.nextResendIn) {
+        setResendCooldown(response.nextResendIn);
+      }
+
+      notifications.show({
+        title: "Thành công",
+        message:
+          response.message ||
+          "Yêu cầu đặt lại mật khẩu đã được gửi. Vui lòng kiểm tra email.",
+        color: "green",
+        autoClose: 3000,
+      });
+    } catch (err: unknown) {
+      let errorMsg = "Gửi lại thất bại. Vui lòng thử lại.";
+
+      if (typeof err === "object" && err !== null && "message" in err) {
+        errorMsg = (err as { message: string }).message;
+      } else if (typeof err === "string") {
+        errorMsg = err;
+      }
+
+      notifications.show({
+        title: "Lỗi",
+        message: errorMsg,
+        color: "red",
+        autoClose: 3000,
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  // Render idle state (form)
+  if (status === "idle" || status === "loading" || status === "error") {
+    return (
+      <Container size={"xs"} my={"xl"}>
+        <Title className={classes.title} ta="center">
+          Quên mật khẩu?
+        </Title>
+        <Text c="dimmed" fz="sm" ta="center">
+          Nhập email của bạn để nhận liên kết đặt lại mật khẩu
+        </Text>
+
+        <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+          <form onSubmit={form.onSubmit(handleSubmit)}>
+            <TextInput
+              label="Email của bạn"
+              placeholder="abc@xyz.com"
+              required
+              disabled={status === "loading"}
+              {...form.getInputProps("email")}
+            />
+
+            {status === "error" && errorMessage && (
+              <Text color="red" size="sm" mt="sm">
+                {errorMessage}
+              </Text>
+            )}
+
+            <Group justify="space-between" mt="lg" className={classes.controls}>
+              <Anchor c="dimmed" size="sm" className={classes.control}>
+                <Center inline>
+                  <IconArrowLeft size={12} stroke={1.5} />
+                  <Box ml={5} onClick={() => navigate("/login")}>
+                    Quay lại trang đăng nhập
+                  </Box>
+                </Center>
+              </Anchor>
+              <Button
+                className={classes.control}
+                loading={status === "loading"}
+                type="submit"
+              >
+                Đặt lại mật khẩu
+              </Button>
+            </Group>
+          </form>
+        </Paper>
+      </Container>
+    );
+  }
+
+  // Render waiting state
+  return (
+    <Container size={"xs"} my={"xl"}>
+      <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+        <Stack align="center">
+          <ThemeIcon size={64} radius="md" variant="light" color="blue">
+            <IconMail size={32} />
+          </ThemeIcon>
+
+          <Title order={2} ta="center">
+            Chờ xác thực
+          </Title>
+
+          <Text ta="center" c="dimmed" size="sm">
+            Nếu email tồn tại trong hệ thống, chúng tôi đã gửi liên kết để đặt
+            lại mật khẩu. Liên kết này sẽ có hiệu lực trong 15 phút.
+          </Text>
+
+          <Text ta="center" size="sm" fw={500}>
+            Không nhận được email?
+          </Text>
+
+          <Group>
+            <Button
+              variant="subtle"
+              disabled={resendCooldown > 0}
+              loading={resendLoading}
+              onClick={handleResendEmail}
+            >
+              {resendCooldown > 0
+                ? `Gửi lại trong ${resendCooldown}s`
+                : "Gửi lại"}
+            </Button>
+          </Group>
+
+          <Button
+            fullWidth
+            variant="subtle"
+            onClick={() => navigate("/login")}
+            mt="lg"
+          >
+            Quay lại đăng nhập
+          </Button>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/pages/login-page/LoginPage.tsx
+++ b/src/pages/login-page/LoginPage.tsx
@@ -10,24 +10,24 @@ import {
   Text,
   TextInput,
   Title,
-} from '@mantine/core';
-import { useForm } from '@mantine/form';
-import { notifications } from '@mantine/notifications';
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
 import {
   type GoogleCredentialResponse,
   GoogleLogin,
-} from '@react-oauth/google';
-import { zod4Resolver } from 'mantine-form-zod-resolver';
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { z } from 'zod';
-import UserService from '../../services/UserService';
-import { useUserStore } from '../../stores/useUserStore';
-import classes from './LoginPage.module.css';
+} from "@react-oauth/google";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { z } from "zod";
+import UserService from "../../services/UserService";
+import { useUserStore } from "../../stores/useUserStore";
+import classes from "./LoginPage.module.css";
 
 const loginSchema = z.object({
-  email: z.email('Định dạng email không hợp lệ'),
-  password: z.string().min(6, 'Mật khẩu phải có ít nhất 6 ký tự'),
+  email: z.email("Định dạng email không hợp lệ"),
+  password: z.string().min(6, "Mật khẩu phải có ít nhất 6 ký tự"),
   rememberMe: z.boolean().optional(),
 });
 
@@ -41,8 +41,8 @@ export default function LoginPage() {
 
   const form = useForm<LoginFormValues>({
     initialValues: {
-      email: '',
-      password: '',
+      email: "",
+      password: "",
       rememberMe: false,
     },
     validate: zod4Resolver(loginSchema),
@@ -57,36 +57,36 @@ export default function LoginPage() {
 
       if (response.success && response.accessToken) {
         // Store token
-        localStorage.setItem('token', response.accessToken);
+        localStorage.setItem("token", response.accessToken);
 
         // Update user store
         setUser(response.user);
 
         // Show success notification
         notifications.show({
-          title: 'Đăng nhập thành công',
+          title: "Đăng nhập thành công",
           message: `Chào mừng trở lại, ${response.user.fullName}!`,
-          color: 'green',
+          color: "green",
           autoClose: 3000,
         });
 
         // Redirect to home page
-        navigate('/', { replace: true });
+        navigate("/", { replace: true });
       }
     } catch (err: unknown) {
-      let errorMessage = 'Đăng nhập thất bại. Vui lòng thử lại.';
+      let errorMessage = "Đăng nhập thất bại. Vui lòng thử lại.";
 
-      if (typeof err === 'object' && err !== null && 'message' in err) {
+      if (typeof err === "object" && err !== null && "message" in err) {
         errorMessage = (err as { message: string }).message;
-      } else if (typeof err === 'string') {
+      } else if (typeof err === "string") {
         errorMessage = err;
       }
 
       setError(errorMessage);
       notifications.show({
-        title: 'Đăng nhập thất bại',
+        title: "Đăng nhập thất bại",
         message: errorMessage,
-        color: 'red',
+        color: "red",
         autoClose: 3000,
       });
     } finally {
@@ -97,12 +97,12 @@ export default function LoginPage() {
   const handleGoogleSuccess = async (
     credentialResponse: GoogleCredentialResponse,
   ) => {
-    console.log('Google Token:', credentialResponse.credential);
+    console.log("Google Token:", credentialResponse.credential);
     if (!credentialResponse.credential) {
       notifications.show({
-        title: 'Đăng nhập Google thất bại',
-        message: 'Không nhận được thông tin từ Google',
-        color: 'red',
+        title: "Đăng nhập Google thất bại",
+        message: "Không nhận được thông tin từ Google",
+        color: "red",
         autoClose: 3000,
       });
       return;
@@ -118,35 +118,35 @@ export default function LoginPage() {
 
       if (response.success && response.accessToken) {
         // Store token
-        localStorage.setItem('token', response.accessToken);
+        localStorage.setItem("token", response.accessToken);
 
         // Update user store
         setUser(response.user);
 
         // Show success notification
         notifications.show({
-          title: 'Đăng nhập thành công',
+          title: "Đăng nhập thành công",
           message: `Chào mừng trở lại, ${response.user.fullName}!`,
-          color: 'green',
+          color: "green",
           autoClose: 3000,
         });
 
         // Redirect to home page
-        navigate('/', { replace: true });
+        navigate("/", { replace: true });
       }
     } catch (err: unknown) {
-      let errorMessage = 'Đăng nhập Google thất bại. Vui lòng thử lại.';
+      let errorMessage = "Đăng nhập Google thất bại. Vui lòng thử lại.";
 
-      if (typeof err === 'object' && err !== null && 'message' in err) {
+      if (typeof err === "object" && err !== null && "message" in err) {
         errorMessage = (err as { message: string }).message;
-      } else if (typeof err === 'string') {
+      } else if (typeof err === "string") {
         errorMessage = err;
       }
 
       notifications.show({
-        title: 'Đăng nhập Google thất bại',
+        title: "Đăng nhập Google thất bại",
         message: errorMessage,
-        color: 'red',
+        color: "red",
         autoClose: 3000,
       });
     } finally {
@@ -156,61 +156,66 @@ export default function LoginPage() {
 
   const handleGoogleError = () => {
     notifications.show({
-      title: 'Đăng nhập Google thất bại',
-      message: 'Không thể xác thực với Google. Vui lòng thử lại.',
-      color: 'red',
+      title: "Đăng nhập Google thất bại",
+      message: "Không thể xác thực với Google. Vui lòng thử lại.",
+      color: "red",
     });
   };
 
   return (
-    <Container size={'xs'} my={'xl'}>
-      <Title ta='center' className={classes.title}>
+    <Container size={"xs"} my={"xl"}>
+      <Title ta="center" className={classes.title}>
         Chào mừng quay trở lại!
       </Title>
 
       <Text className={classes.subtitle}>
-        Bạn chưa có tài khoản?{' '}
-        <Anchor onClick={() => navigate('/register')}>Tạo tài khoản</Anchor>
+        Bạn chưa có tài khoản?{" "}
+        <Anchor onClick={() => navigate("/register")}>Tạo tài khoản</Anchor>
       </Text>
 
-      <Paper withBorder shadow='sm' p={22} mt={30} radius='md'>
+      <Paper withBorder shadow="sm" p={22} mt={30} radius="md">
         <form onSubmit={form.onSubmit(handleSubmit)}>
           <TextInput
-            label='Email'
-            placeholder='you@mantine.dev'
+            label="Email"
+            placeholder="you@mantine.dev"
             required
-            radius='md'
-            {...form.getInputProps('email')}
+            radius="md"
+            {...form.getInputProps("email")}
           />
           <PasswordInput
-            label='Mật khẩu'
-            placeholder='Mật khẩu của bạn'
+            label="Mật khẩu"
+            placeholder="Mật khẩu của bạn"
             required
-            mt='md'
-            radius='md'
-            {...form.getInputProps('password')}
+            mt="md"
+            radius="md"
+            {...form.getInputProps("password")}
           />
-          <Group justify='space-between' mt='lg'>
+          <Group justify="space-between" mt="lg">
             <Checkbox
-              label='Ghi nhớ tôi'
-              {...form.getInputProps('rememberMe', { type: 'checkbox' })}
+              label="Ghi nhớ tôi"
+              {...form.getInputProps("rememberMe", { type: "checkbox" })}
             />
-            <Anchor component='button' size='sm' type='button'>
+            <Anchor
+              component="button"
+              size="sm"
+              type="button"
+              onClick={() => navigate("/forgot-password")}
+            >
               Quên mật khẩu?
             </Anchor>
           </Group>
 
-          <Button fullWidth mt='xl' radius='md' type='submit' loading={loading}>
+          <Button fullWidth mt="xl" radius="md" type="submit" loading={loading}>
             Đăng nhập
           </Button>
         </form>
 
         <Divider
-          label='Hoặc tiếp tục với Google'
-          labelPosition='center'
-          my='lg'
+          label="Hoặc tiếp tục với Google"
+          labelPosition="center"
+          my="lg"
           styles={{
-            label: { color: 'var(--mantine-color-bright)', opacity: 0.85 },
+            label: { color: "var(--mantine-color-bright)", opacity: 0.85 },
           }}
         />
         <GoogleLogin

--- a/src/pages/reset-password/ResetPasswordPage.module.css
+++ b/src/pages/reset-password/ResetPasswordPage.module.css
@@ -1,0 +1,18 @@
+.title {
+  font-size: 26px;
+  font-weight: 500;
+  font-family: Outfit, var(--mantine-font-family);
+}
+
+.controls {
+  @media (max-width: var(--mantine-breakpoint-xs)) {
+    flex-direction: column-reverse;
+  }
+}
+
+.control {
+  @media (max-width: var(--mantine-breakpoint-xs)) {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/pages/reset-password/ResetPasswordPage.tsx
+++ b/src/pages/reset-password/ResetPasswordPage.tsx
@@ -1,0 +1,398 @@
+import { IconArrowLeft, IconCheck, IconX, IconMail } from "@tabler/icons-react";
+import {
+  Anchor,
+  Box,
+  Button,
+  Center,
+  Container,
+  Group,
+  Loader,
+  Paper,
+  PasswordInput,
+  Stack,
+  Text,
+  TextInput,
+  ThemeIcon,
+  Title,
+} from "@mantine/core";
+import classes from "./ResetPasswordPage.module.css";
+import { useForm } from "@mantine/form";
+import z from "zod";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import UserService from "../../services/UserService";
+
+const resetPasswordSchema = z
+  .object({
+    newPassword: z.string().min(8, "Mật khẩu phải có ít nhất 8 ký tự"),
+    confirmPassword: z
+      .string()
+      .min(8, "Xác nhận mật khẩu phải có ít nhất 8 ký tự"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Mật khẩu không khớp",
+    path: ["confirmPassword"],
+  });
+
+const requestNewLinkSchema = z.object({
+  email: z.email("Định dạng email không hợp lệ"),
+});
+
+type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;
+type RequestNewLinkValues = z.infer<typeof requestNewLinkSchema>;
+
+type Status = "loading" | "waiting" | "success" | "error" | "token-expired";
+
+export default function ResetPasswordPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const [status, setStatus] = useState<Status>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [visible, { toggle }] = useDisclosure(false);
+  const [formLoading, setFormLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  const token = searchParams.get("token");
+
+  const form = useForm<ResetPasswordFormValues>({
+    initialValues: {
+      newPassword: "",
+      confirmPassword: "",
+    },
+    validate: zod4Resolver(resetPasswordSchema),
+  });
+
+  const requestNewLinkForm = useForm<RequestNewLinkValues>({
+    initialValues: {
+      email: "",
+    },
+    validate: zod4Resolver(requestNewLinkSchema),
+  });
+
+  // Cooldown timer effect
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+
+    const timer = setInterval(() => {
+      setResendCooldown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [resendCooldown]);
+
+  // Verify token on mount
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("Link không hợp lệ. Vui lòng yêu cầu link mới.");
+      return;
+    }
+
+    // Token validation - we'll do simple check, actual validation happens on confirm
+    // For now just set to waiting since we can't validate without calling backend
+    setStatus("waiting");
+  }, [token]);
+
+  const handleSubmit = async (values: ResetPasswordFormValues) => {
+    if (!token) {
+      notifications.show({
+        title: "Lỗi",
+        message: "Link không hợp lệ",
+        color: "red",
+        autoClose: 3000,
+      });
+      return;
+    }
+
+    setFormLoading(true);
+
+    try {
+      const response = await UserService.confirmPasswordReset(
+        token,
+        values.newPassword,
+        values.confirmPassword,
+      );
+
+      setStatus("success");
+      setSuccessMessage(response.message);
+
+      notifications.show({
+        title: "Thành công",
+        message: response.message || "Mật khẩu đã được đặt lại thành công!",
+        color: "green",
+        autoClose: 3000,
+      });
+    } catch (err: unknown) {
+      let errorMsg = "Đặt lại mật khẩu thất bại. Vui lòng thử lại.";
+
+      if (typeof err === "object" && err !== null && "message" in err) {
+        errorMsg = (err as { message: string }).message;
+      } else if (typeof err === "string") {
+        errorMsg = err;
+      }
+
+      // Check if error is token-expired
+      if (
+        errorMsg.toLowerCase().includes("hết hạn") ||
+        errorMsg.toLowerCase().includes("expired")
+      ) {
+        setStatus("token-expired");
+        setErrorMessage(errorMsg);
+      } else {
+        setStatus("error");
+        setErrorMessage(errorMsg);
+      }
+
+      notifications.show({
+        title: "Lỗi",
+        message: errorMsg,
+        color: "red",
+        autoClose: 3000,
+      });
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  const handleResendLink = async (values: RequestNewLinkValues) => {
+    setResendLoading(true);
+    try {
+      const response = await UserService.requestPasswordReset(values.email);
+
+      // Set cooldown from response
+      if (response.nextResendIn) {
+        setResendCooldown(response.nextResendIn);
+      }
+
+      notifications.show({
+        title: "Thành công",
+        message:
+          response.message ||
+          "Nếu email tồn tại, bạn sẽ nhận được liên kết mới.",
+        color: "green",
+        autoClose: 3000,
+      });
+
+      // Clear form
+      requestNewLinkForm.reset();
+    } catch (err: unknown) {
+      let errorMsg = "Gửi lại thất bại. Vui lòng thử lại.";
+
+      if (typeof err === "object" && err !== null && "message" in err) {
+        errorMsg = (err as { message: string }).message;
+      } else if (typeof err === "string") {
+        errorMsg = err;
+      }
+
+      notifications.show({
+        title: "Lỗi",
+        message: errorMsg,
+        color: "red",
+        autoClose: 3000,
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  };
+
+  // Render loading state
+  if (status === "loading") {
+    return (
+      <Container size={"xs"} my={"xl"}>
+        <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+          <Stack align="center">
+            <Loader />
+            <Text c="dimmed" ta="center">
+              Đang xác thực liên kết...
+            </Text>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  // Render error state (invalid token)
+  if (status === "error") {
+    return (
+      <Container size={"xs"} my={"xl"}>
+        <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+          <Stack align="center">
+            <ThemeIcon size={64} radius="md" variant="light" color="red">
+              <IconX size={32} />
+            </ThemeIcon>
+
+            <Title order={2} ta="center">
+              Đặt lại mật khẩu thất bại
+            </Title>
+
+            <Text ta="center" c="dimmed" size="sm">
+              {errorMessage || "Link không hợp lệ. Vui lòng yêu cầu link mới."}
+            </Text>
+
+            <Button
+              fullWidth
+              onClick={() => navigate("/forgot-password")}
+              mt="lg"
+            >
+              Yêu cầu link mới
+            </Button>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  // Render token-expired state (with resend form)
+  if (status === "token-expired") {
+    return (
+      <Container size={"xs"} my={"xl"}>
+        <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+          <Stack align="center">
+            <ThemeIcon size={64} radius="md" variant="light" color="orange">
+              <IconMail size={32} />
+            </ThemeIcon>
+
+            <Title order={2} ta="center">
+              Liên kết đã hết hạn
+            </Title>
+
+            <Text ta="center" c="dimmed" size="sm">
+              Liên kết đặt lại mật khẩu của bạn đã hết hạn. Vui lòng nhập email
+              để nhận liên kết mới.
+            </Text>
+
+            <form
+              onSubmit={requestNewLinkForm.onSubmit(handleResendLink)}
+              style={{ width: "100%" }}
+            >
+              <Stack>
+                <TextInput
+                  label="Email của bạn"
+                  placeholder="abc@xyz.com"
+                  disabled={resendLoading}
+                  {...requestNewLinkForm.getInputProps("email")}
+                />
+                <Button
+                  fullWidth
+                  type="submit"
+                  loading={resendLoading}
+                  disabled={resendCooldown > 0}
+                >
+                  {resendCooldown > 0
+                    ? `Gửi lại trong ${resendCooldown}s`
+                    : "Gửi lại liên kết"}
+                </Button>
+              </Stack>
+            </form>
+
+            <Anchor
+              c="dimmed"
+              size="sm"
+              onClick={() => navigate("/forgot-password")}
+              style={{ cursor: "pointer" }}
+            >
+              <Center inline>
+                <IconArrowLeft size={12} stroke={1.5} />
+                <Box ml={5}>Quay lại trang yêu cầu</Box>
+              </Center>
+            </Anchor>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  // Render success state
+  if (status === "success") {
+    return (
+      <Container size={"xs"} my={"xl"}>
+        <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+          <Stack align="center">
+            <ThemeIcon size={64} radius="md" variant="light" color="teal">
+              <IconCheck size={32} />
+            </ThemeIcon>
+
+            <Title order={2} ta="center">
+              Đặt lại mật khẩu thành công!
+            </Title>
+
+            <Text ta="center" c="dimmed" size="sm">
+              {successMessage ||
+                "Mật khẩu của bạn đã được cập nhật. Vui lòng đăng nhập bằng mật khẩu mới."}
+            </Text>
+
+            <Button
+              fullWidth
+              onClick={() => navigate("/login", { replace: true })}
+              mt="lg"
+            >
+              Đăng nhập ngay
+            </Button>
+          </Stack>
+        </Paper>
+      </Container>
+    );
+  }
+
+  // Render form state (waiting)
+  return (
+    <Container size={"xs"} my={"xl"}>
+      <Title className={classes.title} ta="center">
+        Đặt lại mật khẩu
+      </Title>
+      <Text c="dimmed" fz="sm" ta="center">
+        Nhập mật khẩu mới cho tài khoản của bạn
+      </Text>
+
+      <Paper withBorder shadow="md" p={30} radius="md" mt="xl">
+        <form onSubmit={form.onSubmit(handleSubmit)}>
+          <Stack>
+            <PasswordInput
+              label="Mật khẩu mới"
+              placeholder="Nhập mật khẩu mới"
+              visible={visible}
+              onVisibilityChange={toggle}
+              disabled={formLoading}
+              {...form.getInputProps("newPassword")}
+            />
+            <PasswordInput
+              label="Xác nhận mật khẩu"
+              placeholder="Nhập lại mật khẩu"
+              visible={visible}
+              onVisibilityChange={toggle}
+              disabled={formLoading}
+              {...form.getInputProps("confirmPassword")}
+            />
+          </Stack>
+          <Button
+            fullWidth
+            mt="xl"
+            radius="md"
+            type="submit"
+            loading={formLoading}
+          >
+            Đặt lại mật khẩu
+          </Button>
+
+          <Group justify="center" mt="lg">
+            <Anchor
+              c="dimmed"
+              size="sm"
+              onClick={() => navigate("/forgot-password")}
+            >
+              <Center inline>
+                <IconArrowLeft size={12} stroke={1.5} />
+                <Box ml={5}>Quay lại yêu cầu link mới</Box>
+              </Center>
+            </Anchor>
+          </Group>
+        </form>
+      </Paper>
+    </Container>
+  );
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,22 +1,24 @@
 // src/routes/index.tsx
-import { createBrowserRouter } from 'react-router-dom';
-import { ProtectedRoute } from '../components/common/ProtectedRoute';
-import Layout from '../layouts/Layout';
-import { AuthorProfile } from '../pages/author-profile/AuthorProfile';
-import BuyVipPlanPage from '../pages/buy-vip-plan/BuyVipPlanPage';
-import HomePage from '../pages/home-page/HomePage';
-import LoginPage from '../pages/login-page/LoginPage';
-import BuyStonePage from '../pages/purchase/buy-stone/BuyStonePage';
-import RegisterPage from '../pages/register-page/RegisterPage';
-import StoryDetailPage from '../pages/story-detail-page/StoryDetailPage';
-import UserProfile from '../pages/user-profile/UserProfile';
-import VerifyEmailPage from '../pages/verify-email-page/VerifyEmailPage';
-import { AdminRoute } from './admin';
+import { createBrowserRouter } from "react-router-dom";
+import { ProtectedRoute } from "../components/common/ProtectedRoute";
+import Layout from "../layouts/Layout";
+import { AuthorProfile } from "../pages/author-profile/AuthorProfile";
+import BuyVipPlanPage from "../pages/buy-vip-plan/BuyVipPlanPage";
+import HomePage from "../pages/home-page/HomePage";
+import LoginPage from "../pages/login-page/LoginPage";
+import BuyStonePage from "../pages/purchase/buy-stone/BuyStonePage";
+import RegisterPage from "../pages/register-page/RegisterPage";
+import StoryDetailPage from "../pages/story-detail-page/StoryDetailPage";
+import UserProfile from "../pages/user-profile/UserProfile";
+import VerifyEmailPage from "../pages/verify-email-page/VerifyEmailPage";
+import { AdminRoute } from "./admin";
+import ForgotPasswordPage from "../pages/forgot-password/ForgotPasswordPage";
+import ResetPasswordPage from "../pages/reset-password/ResetPasswordPage";
 
 const routes = createBrowserRouter([
   AdminRoute,
   {
-    path: '/',
+    path: "/",
     element: <Layout />,
     children: [
       {
@@ -24,31 +26,39 @@ const routes = createBrowserRouter([
         element: <HomePage />,
       },
       {
-        path: 'login',
+        path: "login",
         element: <LoginPage />,
       },
       {
-        path: 'register',
+        path: "register",
         element: <RegisterPage />,
       },
       {
-        path: 'verify-email',
+        path: "forgot-password",
+        element: <ForgotPasswordPage />,
+      },
+      {
+        path: "verify-email",
         element: <VerifyEmailPage />,
       },
       {
-        path: 'author-profile',
+        path: "reset-password",
+        element: <ResetPasswordPage />,
+      },
+      {
+        path: "author-profile",
         element: <AuthorProfile />,
       },
       {
-        path: 'purchase/spirit-stone',
+        path: "purchase/spirit-stone",
         element: <BuyStonePage />,
       },
       {
-        path: 'purchase/vip-plan',
+        path: "purchase/vip-plan",
         element: <BuyVipPlanPage />,
       },
       {
-        path: 'story/:slug',
+        path: "story/:slug",
         element: <StoryDetailPage />,
       },
       // Routes below require the user to be authenticated with a valid token.
@@ -56,13 +66,13 @@ const routes = createBrowserRouter([
         element: <ProtectedRoute />,
         children: [
           {
-            path: 'user-profile',
+            path: "user-profile",
             element: <UserProfile />,
           },
         ],
       },
       {
-        path: '*',
+        path: "*",
         element: <HomePage />,
       },
     ],

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
-import axiosClient from '../api/axiosClient';
-import { instance } from './../lib/axios';
+import axios from "axios";
+import axiosClient from "../api/axiosClient";
+import { instance } from "./../lib/axios";
 
 export interface LoginCredentials {
   email: string;
@@ -16,8 +16,8 @@ export interface AuthResponse {
     email: string;
     username: string;
     fullName: string;
-    role: 'admin' | 'author' | 'user';
-    status: 'active' | 'inactive' | 'banned';
+    role: "admin" | "author" | "user";
+    status: "active" | "inactive" | "banned";
     avatarURL?: string;
     vipLevel: number;
   };
@@ -46,6 +46,17 @@ export interface ResendVerificationResponse {
   nextResendIn?: number;
 }
 
+export interface PasswordResetRequestResponse {
+  success: boolean;
+  message: string;
+  nextResendIn?: number;
+}
+
+export interface PasswordResetConfirmResponse {
+  success: boolean;
+  message: string;
+}
+
 export interface UpdateProfileRequest {
   fullName?: string;
   nickName?: string;
@@ -56,7 +67,7 @@ export interface UpdateProfileRequest {
 const UserService = {
   async register(credentials: RegisterCredentials): Promise<RegisterResponse> {
     try {
-      const response = await instance.post('/auth/register', {
+      const response = await instance.post("/auth/register", {
         name: credentials.name,
         email: credentials.email,
         password: credentials.password,
@@ -64,30 +75,30 @@ const UserService = {
       });
       return response.data;
     } catch (error: unknown) {
-      console.error('Lỗi đăng ký:', error);
+      console.error("Lỗi đăng ký:", error);
       if (axios.isAxiosError(error) && error.response) {
         throw error.response?.data || error.message;
       }
       throw error instanceof Error
         ? error.message
-        : 'Có lỗi không xác định xảy ra';
+        : "Có lỗi không xác định xảy ra";
     }
   },
 
   async verifyEmail(token: string): Promise<VerifyEmailResponse> {
     try {
-      const response = await instance.get('/auth/verify-email', {
+      const response = await instance.get("/auth/verify-email", {
         params: { token },
       });
       return response.data;
     } catch (error: unknown) {
-      console.error('Lỗi xác thực email:', error);
+      console.error("Lỗi xác thực email:", error);
       if (axios.isAxiosError(error) && error.response) {
         throw error.response?.data || error.message;
       }
       throw error instanceof Error
         ? error.message
-        : 'Có lỗi không xác định xảy ra';
+        : "Có lỗi không xác định xảy ra";
     }
   },
 
@@ -95,24 +106,24 @@ const UserService = {
     email: string,
   ): Promise<ResendVerificationResponse> {
     try {
-      const response = await instance.post('/auth/resend-verification', {
+      const response = await instance.post("/auth/resend-verification", {
         email,
       });
       return response.data;
     } catch (error: unknown) {
-      console.error('Lỗi gửi lại email xác thực:', error);
+      console.error("Lỗi gửi lại email xác thực:", error);
       if (axios.isAxiosError(error) && error.response) {
         throw error.response?.data || error.message;
       }
       throw error instanceof Error
         ? error.message
-        : 'Có lỗi không xác định xảy ra';
+        : "Có lỗi không xác định xảy ra";
     }
   },
 
   async login(credentials: LoginCredentials): Promise<AuthResponse> {
     try {
-      const response = await instance.post('/auth/login', credentials);
+      const response = await instance.post("/auth/login", credentials);
       // Extract data from wrapper
       const { success, data } = response.data;
       return {
@@ -121,13 +132,13 @@ const UserService = {
         user: data.user,
       };
     } catch (error: unknown) {
-      console.error('Lỗi đăng nhập:', error);
+      console.error("Lỗi đăng nhập:", error);
       if (axios.isAxiosError(error) && error.response) {
         throw error.response?.data || error.message;
       }
       throw error instanceof Error
         ? error.message
-        : 'Có lỗi không xác định xảy ra';
+        : "Có lỗi không xác định xảy ra";
     }
   },
 
@@ -152,7 +163,7 @@ const UserService = {
     rememberMe: boolean = false,
   ): Promise<AuthResponse> {
     try {
-      const response = await instance.post('/auth/google-login', {
+      const response = await instance.post("/auth/google-login", {
         token,
         rememberMe,
       });
@@ -169,12 +180,12 @@ const UserService = {
       }
       throw error instanceof Error
         ? error.message
-        : 'Có lỗi không xác định xảy ra';
+        : "Có lỗi không xác định xảy ra";
     }
   },
 
   async getProfile() {
-    const res = await axiosClient.get('/user/profile');
+    const res = await axiosClient.get("/user/profile");
     return res.data.data;
   },
 
@@ -188,22 +199,64 @@ const UserService = {
   }) {
     const formData = new FormData();
 
-    if (data.fullName) formData.append('fullName', data.fullName);
-    if (data.nickName) formData.append('nickName', data.nickName);
-    if (data.penName) formData.append('penName', data.penName);
-    if (data.bio) formData.append('bio', data.bio);
+    if (data.fullName) formData.append("fullName", data.fullName);
+    if (data.nickName) formData.append("nickName", data.nickName);
+    if (data.penName) formData.append("penName", data.penName);
+    if (data.bio) formData.append("bio", data.bio);
 
     if (data.avatarFile) {
-      formData.append('avatarURL', data.avatarFile);
+      formData.append("avatarURL", data.avatarFile);
     }
 
     if (data.backgroundFile) {
-      formData.append('backgroundURL', data.backgroundFile);
+      formData.append("backgroundURL", data.backgroundFile);
     }
 
-    const res = await axiosClient.put('/user/profile', formData);
+    const res = await axiosClient.put("/user/profile", formData);
 
     return res.data.data;
+  },
+
+  async requestPasswordReset(
+    email: string,
+  ): Promise<PasswordResetRequestResponse> {
+    try {
+      const response = await instance.post("/auth/password-reset-request", {
+        email,
+      });
+      return response.data;
+    } catch (error: unknown) {
+      console.error("Lỗi yêu cầu đặt lại mật khẩu:", error);
+      if (axios.isAxiosError(error) && error.response) {
+        throw error.response?.data || error.message;
+      }
+      throw error instanceof Error
+        ? error.message
+        : "Có lỗi không xác định xảy ra";
+    }
+  },
+
+  async confirmPasswordReset(
+    token: string,
+    newPassword: string,
+    confirmPassword: string,
+  ): Promise<PasswordResetConfirmResponse> {
+    try {
+      const response = await instance.post("/auth/password-reset-confirm", {
+        token,
+        newPassword,
+        confirmPassword,
+      });
+      return response.data;
+    } catch (error: unknown) {
+      console.error("Lỗi xác nhận đặt lại mật khẩu:", error);
+      if (axios.isAxiosError(error) && error.response) {
+        throw error.response?.data || error.message;
+      }
+      throw error instanceof Error
+        ? error.message
+        : "Có lỗi không xác định xảy ra";
+    }
   },
 };
 


### PR DESCRIPTION
Introduce ForgotPasswordPage and ResetPasswordPage with accompanying CSS modules and UX (form validation, resend cooldown, token handling, notifications). Add routes for /forgot-password and /reset-password and wire the login page to navigate to the forgot-password flow. Extend UserService with types and methods for password reset request and confirm endpoints, plus minor code/style cleanups and consistent quoting.