### PR TITLE
Add chapters modal, editor fixes & logout cleanup

### DIFF
--- a/src/components/HistoryTable.tsx
+++ b/src/components/HistoryTable.tsx
@@ -1,50 +1,60 @@
 import { Table } from "@mantine/core";
 import { Link } from "react-router-dom";
 import { useLast3History } from "../hooks/useHistory";
+import { useUserStore } from "../stores/useUserStore";
 import type { StoryItem } from "../interfaces/Story";
 import StoryItemCard from "./story/StoryItemCard";
 
 const HistoryTable = () => {
-	const { data: historyList } = useLast3History();
+  const { isLoggedIn } = useUserStore();
+  const { data: historyList } = useLast3History();
 
-	return (
-		<div className="border border-1 border-gray-300 px-3 rounded-sm">
-			<Table horizontalSpacing={0} verticalSpacing={"sm"}>
-				<Table.Thead>
-					<Table.Tr>
-						<Table.Td>
-							<div className="flex justify-between items-center py-3">
-								<p className="text-[16px] font-semibold">Lịch sử đọc truyện</p>
-								<Link
-									to={"/user-profile?tab=history"}
-									className="text-[13px] font-semibold cursor-pointer underline hover:text-blue-500"
-								>
-									Xem tất cả
-								</Link>
-							</div>
-						</Table.Td>
-					</Table.Tr>
-				</Table.Thead>
-				<Table.Tbody>
-					{historyList?.length > 0 ? (
-						historyList?.map((item: StoryItem) => (
-							<Table.Tr key={item.id}>
-								<Table.Td>
-									<StoryItemCard story={item} type="history" />
-								</Table.Td>
-							</Table.Tr>
-						))
-					) : (
-						<Table.Tr>
-							<Table.Td>
-								<p className="text-center py-1">Chưa có lịch sử đọc truyện</p>
-							</Table.Td>
-						</Table.Tr>
-					)}
-				</Table.Tbody>
-			</Table>
-		</div>
-	);
+  return (
+    <div className="border border-1 border-gray-300 px-3 rounded-sm">
+      <Table horizontalSpacing={0} verticalSpacing={"sm"}>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Td>
+              <div className="flex justify-between items-center py-3">
+                <p className="text-[16px] font-semibold">Lịch sử đọc truyện</p>
+                <Link
+                  to={"/user-profile?tab=history"}
+                  className="text-[13px] font-semibold cursor-pointer underline hover:text-blue-500"
+                >
+                  Xem tất cả
+                </Link>
+              </div>
+            </Table.Td>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {isLoggedIn ? (
+            historyList?.length > 0 ? (
+              historyList?.map((item: StoryItem) => (
+                <Table.Tr key={item.id}>
+                  <Table.Td>
+                    <StoryItemCard story={item} type="history" />
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            ) : (
+              <Table.Tr>
+                <Table.Td>
+                  <p className="text-center py-1">Chưa có lịch sử đọc truyện</p>
+                </Table.Td>
+              </Table.Tr>
+            )
+          ) : (
+            <Table.Tr>
+              <Table.Td>
+                <p className="text-center py-1">Chưa có lịch sử đọc truyện</p>
+              </Table.Td>
+            </Table.Tr>
+          )}
+        </Table.Tbody>
+      </Table>
+    </div>
+  );
 };
 
 export default HistoryTable;

--- a/src/components/author/ChapterContentInput.tsx
+++ b/src/components/author/ChapterContentInput.tsx
@@ -1,13 +1,4 @@
-import {
-  ActionIcon,
-  Group,
-  Paper,
-  SegmentedControl,
-  Stack,
-  Text,
-  ThemeIcon,
-} from "@mantine/core";
-import { Dropzone, MS_WORD_MIME_TYPE, PDF_MIME_TYPE } from "@mantine/dropzone";
+import { ActionIcon, Group, Stack, Text } from "@mantine/core";
 import { Link, RichTextEditor } from "@mantine/tiptap";
 import CodeBlock from "@tiptap/extension-code-block";
 import Highlight from "@tiptap/extension-highlight";
@@ -17,26 +8,18 @@ import Superscript from "@tiptap/extension-superscript";
 import Underline from "@tiptap/extension-underline";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { FileText, Upload, X } from "lucide-react";
+import { Upload } from "lucide-react";
 import { useRef, useState, useEffect } from "react";
 import { instance as axios } from "../../lib/axios";
 import { showError } from "../../utils/notifications";
 
-export type ContentPayload =
-  | { mode: "editor"; html: string }
-  | { mode: "upload"; file: File };
+export type ContentPayload = { mode: "editor"; html: string };
 
 interface ChapterContentInputProps {
   onChange: (payload: ContentPayload | null) => void;
   /** Pre-load HTML content (for edit mode) */
   initialContent?: string;
   error?: string;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function wordCount(text: string): number {
@@ -67,8 +50,6 @@ export function ChapterContentInput({
   initialContent,
   error,
 }: ChapterContentInputProps) {
-  const [mode, setMode] = useState<"editor" | "upload">("editor");
-  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [words, setWords] = useState(0);
   const imageInputRef = useRef<HTMLInputElement>(null);
 
@@ -105,16 +86,6 @@ export function ChapterContentInput({
       }
     }
   }, [initialContent, editor]);
-
-  const handleModeChange = (val: string) => {
-    const next = val as "editor" | "upload";
-    setMode(next);
-    if (next === "editor") {
-      onChange(editor ? { mode: "editor", html: editor.getHTML() } : null);
-    } else {
-      onChange(uploadedFile ? { mode: "upload", file: uploadedFile } : null);
-    }
-  };
 
   const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -166,212 +137,108 @@ export function ChapterContentInput({
     }
   };
 
-  const handleDrop = (files: File[]) => {
-    const file = files[0];
-    setUploadedFile(file);
-    onChange({ mode: "upload", file });
-  };
-
-  const handleRemoveFile = () => {
-    setUploadedFile(null);
-    onChange(null);
-  };
-
   const errorBorder = error
     ? "1px solid var(--mantine-color-red-6)"
     : undefined;
 
   return (
     <Stack gap="sm">
-      <SegmentedControl
-        value={mode}
-        onChange={handleModeChange}
-        size="sm"
-        w="fit-content"
-        data={[
-          { label: "Soạn thảo trực tiếp", value: "editor" },
-          { label: "Tải file lên", value: "upload" },
-        ]}
-      />
+      <Stack gap={4}>
+        <RichTextEditor editor={editor} style={{ border: errorBorder }}>
+          <RichTextEditor.Toolbar sticky stickyOffset={60}>
+            {/* Inline formatting */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Bold />
+              <RichTextEditor.Italic />
+              <RichTextEditor.Underline />
+              <RichTextEditor.Strikethrough />
+              <RichTextEditor.ClearFormatting />
+              <RichTextEditor.Highlight />
+              <RichTextEditor.Code />
+            </RichTextEditor.ControlsGroup>
 
-      {/* ── Rich-text editor mode ── */}
-      {mode === "editor" && (
-        <Stack gap={4}>
-          <RichTextEditor editor={editor} style={{ border: errorBorder }}>
-            <RichTextEditor.Toolbar sticky stickyOffset={60}>
-              {/* Inline formatting */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Bold />
-                <RichTextEditor.Italic />
-                <RichTextEditor.Underline />
-                <RichTextEditor.Strikethrough />
-                <RichTextEditor.ClearFormatting />
-                <RichTextEditor.Highlight />
-                <RichTextEditor.Code />
-              </RichTextEditor.ControlsGroup>
+            {/* Headings */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.H1 />
+              <RichTextEditor.H2 />
+              <RichTextEditor.H3 />
+              <RichTextEditor.H4 />
+            </RichTextEditor.ControlsGroup>
 
-              {/* Headings */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.H1 />
-                <RichTextEditor.H2 />
-                <RichTextEditor.H3 />
-                <RichTextEditor.H4 />
-              </RichTextEditor.ControlsGroup>
+            {/* Blocks */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Blockquote />
+              <RichTextEditor.Hr />
+              <RichTextEditor.BulletList />
+              <RichTextEditor.OrderedList />
+              <RichTextEditor.Superscript />
+              <RichTextEditor.CodeBlock />
+            </RichTextEditor.ControlsGroup>
 
-              {/* Blocks */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Blockquote />
-                <RichTextEditor.Hr />
-                <RichTextEditor.BulletList />
-                <RichTextEditor.OrderedList />
-                <RichTextEditor.Superscript />
-                <RichTextEditor.CodeBlock />
-              </RichTextEditor.ControlsGroup>
+            {/* Links */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Link />
+              <RichTextEditor.Unlink />
+            </RichTextEditor.ControlsGroup>
 
-              {/* Links */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Link />
-                <RichTextEditor.Unlink />
-              </RichTextEditor.ControlsGroup>
-
-              {/* Image */}
-              <RichTextEditor.ControlsGroup>
-                <ActionIcon
-                  onClick={handleImageInsert}
-                  aria-label="Chèn ảnh"
-                  title="Chèn ảnh (Ctrl+Shift+I)"
-                  variant="default"
-                  size={36}
-                >
-                  <Upload size={16} />
-                </ActionIcon>
-              </RichTextEditor.ControlsGroup>
-
-              {/* Alignment */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.AlignLeft />
-                <RichTextEditor.AlignCenter />
-                <RichTextEditor.AlignRight />
-                <RichTextEditor.AlignJustify />
-              </RichTextEditor.ControlsGroup>
-
-              {/* History */}
-              <RichTextEditor.ControlsGroup>
-                <RichTextEditor.Undo />
-                <RichTextEditor.Redo />
-              </RichTextEditor.ControlsGroup>
-            </RichTextEditor.Toolbar>
-
-            <RichTextEditor.Content
-              style={{
-                fontFamily: "'Poppins', 'Open Sans', sans-serif",
-                fontSize: "16px",
-                lineHeight: "1.8",
-                minHeight: 400,
-              }}
-              onPaste={handlePaste}
-            />
-          </RichTextEditor>
-
-          <Group justify="space-between">
-            {error ? (
-              <Text size="xs" c="red">
-                {error}
-              </Text>
-            ) : (
-              <span />
-            )}
-            <Text size="xs" c="dimmed">
-              {words.toLocaleString("vi-VN")} từ
-              {words > 0 && words < 50 && (
-                <Text span c="blue" inherit>
-                  {" "}
-                  (cần ít nhất 50 từ)
-                </Text>
-              )}
-            </Text>
-          </Group>
-        </Stack>
-      )}
-
-      {/* ── File upload mode ── */}
-      {mode === "upload" && (
-        <Stack gap="sm">
-          {uploadedFile ? (
-            <Paper withBorder p="md" radius="md">
-              <Group justify="space-between">
-                <Group gap="sm">
-                  <ThemeIcon variant="light" color="blue" size="lg" radius="md">
-                    <FileText size={18} />
-                  </ThemeIcon>
-                  <Stack gap={2}>
-                    <Text size="sm" fw={500} lineClamp={1} maw={400}>
-                      {uploadedFile.name}
-                    </Text>
-                    <Text size="xs" c="dimmed">
-                      {formatBytes(uploadedFile.size)}
-                    </Text>
-                  </Stack>
-                </Group>
-                <ActionIcon
-                  variant="subtle"
-                  color="red"
-                  size="sm"
-                  onClick={handleRemoveFile}
-                  aria-label="Xóa file"
-                >
-                  <X size={14} />
-                </ActionIcon>
-              </Group>
-            </Paper>
-          ) : (
-            <Dropzone
-              onDrop={handleDrop}
-              accept={[...MS_WORD_MIME_TYPE, ...PDF_MIME_TYPE, "text/plain"]}
-              maxSize={50 * 1024 * 1024}
-              multiple={false}
-              styles={{
-                root: errorBorder ? { border: errorBorder } : undefined,
-              }}
-            >
-              <Group
-                justify="center"
-                gap="xl"
-                mih={220}
-                style={{ pointerEvents: "none" }}
+            {/* Image */}
+            <RichTextEditor.ControlsGroup>
+              <ActionIcon
+                onClick={handleImageInsert}
+                aria-label="Chèn ảnh"
+                title="Chèn ảnh (Ctrl+Shift+I)"
+                variant="default"
+                size={36}
               >
-                <Dropzone.Accept>
-                  <Upload size={48} color="var(--mantine-color-blue-6)" />
-                </Dropzone.Accept>
-                <Dropzone.Reject>
-                  <X size={48} color="var(--mantine-color-red-6)" />
-                </Dropzone.Reject>
-                <Dropzone.Idle>
-                  <Upload size={48} color="var(--mantine-color-dimmed)" />
-                </Dropzone.Idle>
+                <Upload size={16} />
+              </ActionIcon>
+            </RichTextEditor.ControlsGroup>
 
-                <Stack gap={6} align="center">
-                  <Text size="md" fw={500} ta="center">
-                    Kéo thả file vào đây hoặc{" "}
-                    <Text span c="blue" inherit>
-                      nhấn để chọn file
-                    </Text>
-                  </Text>
-                  <Text size="xs" c="dimmed" ta="center">
-                    Hỗ trợ: .docx, .pdf, .txt &bull; Tối đa 50 MB
-                  </Text>
-                </Stack>
-              </Group>
-            </Dropzone>
-          )}
+            {/* Alignment */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.AlignLeft />
+              <RichTextEditor.AlignCenter />
+              <RichTextEditor.AlignRight />
+              <RichTextEditor.AlignJustify />
+            </RichTextEditor.ControlsGroup>
 
-          {error && (
+            {/* History */}
+            <RichTextEditor.ControlsGroup>
+              <RichTextEditor.Undo />
+              <RichTextEditor.Redo />
+            </RichTextEditor.ControlsGroup>
+          </RichTextEditor.Toolbar>
+
+          <RichTextEditor.Content
+            style={{
+              fontFamily: "'Poppins', 'Open Sans', sans-serif",
+              fontSize: "16px",
+              lineHeight: "1.8",
+              minHeight: 400,
+            }}
+            onPaste={handlePaste}
+          />
+        </RichTextEditor>
+
+        <Group justify="space-between">
+          {error ? (
             <Text size="xs" c="red">
               {error}
             </Text>
+          ) : (
+            <span />
           )}
-        </Stack>
-      )}
+          <Text size="xs" c="dimmed">
+            {words.toLocaleString("vi-VN")} từ
+            {words > 0 && words < 50 && (
+              <Text span c="blue" inherit>
+                {" "}
+                (cần ít nhất 50 từ để đăng)
+              </Text>
+            )}
+          </Text>
+        </Group>
+      </Stack>
 
       {/* Hidden image file input */}
       <input

--- a/src/components/author/ChaptersListModal.tsx
+++ b/src/components/author/ChaptersListModal.tsx
@@ -1,0 +1,150 @@
+import {
+  Badge,
+  Button,
+  Flex,
+  Group,
+  Loader,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import { Plus } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import type { Chapter } from "../../interfaces/Chapter";
+import { useChaptersByStoryForAuthor } from "../../hooks/useChapter";
+import { timeAgo } from "../../utils";
+
+interface ChaptersListModalProps {
+  opened: boolean;
+  onClose: () => void;
+  storyId: string;
+  storySlug: string;
+  storyTitle: string;
+}
+
+const statusConfig: Record<string, { label: string; color: string }> = {
+  draft: { label: "Bản nháp", color: "gray" },
+  pending: { label: "Chờ duyệt", color: "yellow" },
+  active: { label: "Đã duyệt", color: "green" },
+  rejected: { label: "Bị từ chối", color: "red" },
+  banned: { label: "Bị cấm", color: "red.9" },
+};
+
+export default function ChaptersListModal({
+  opened,
+  onClose,
+  storyId,
+  storySlug,
+  storyTitle,
+}: ChaptersListModalProps) {
+  const navigate = useNavigate();
+  const { data: chapters = [], isLoading, error } = useChaptersByStoryForAuthor(
+    storyId,
+  );
+
+  const handleChapterClick = (chapterNumber: number) => {
+    onClose();
+    navigate(`/author/story/${storySlug}/write-chapter?chapter=${chapterNumber}`);
+  };
+
+  const handleCreateNewChapter = () => {
+    onClose();
+    navigate(`/author/story/${storySlug}/write-chapter`);
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      centered
+      size="lg"
+      radius="lg"
+      withCloseButton
+      title={
+        <Title order={2} ta="center" w="100%" size="h4">
+          {storyTitle}
+        </Title>
+      }
+      styles={{
+        header: {
+          width: "100%",
+        },
+        title: {
+          width: "100%",
+        },
+        body: {
+          paddingTop: 8,
+        },
+      }}
+    >
+      {isLoading ? (
+        <Flex justify="center" py="xl">
+          <Loader size="lg" />
+        </Flex>
+      ) : error ? (
+        <Text c="red">Không thể tải danh sách chương</Text>
+      ) : chapters.length === 0 ? (
+        <Stack align="center" py="xl" gap="md">
+          <Text c="dimmed">Chưa có chương nào</Text>
+          <Button
+            color="orange"
+            leftSection={<Plus size={16} />}
+            onClick={handleCreateNewChapter}
+          >
+            Tạo chương đầu tiên
+          </Button>
+        </Stack>
+      ) : (
+        <Stack gap={0}>
+          <ScrollArea.Autosize mah={520} offsetScrollbars>
+            <Stack gap="sm" pr="md">
+              {chapters.map((chapter: Chapter) => {
+                const cfg =
+                  statusConfig[chapter.status] || statusConfig.draft;
+                return (
+                  <Flex
+                    key={chapter._id}
+                    justify="space-between"
+                    align="center"
+                    p="sm"
+                    className="border border-gray-200 rounded-md hover:bg-gray-50 cursor-pointer transition-colors"
+                    onClick={() => handleChapterClick(chapter.chapterNumber)}
+                  >
+                    <Stack gap={4} style={{ flex: 1 }}>
+                      <Group gap="sm">
+                        <Text fw={500} size="sm">
+                          Chương {chapter.chapterNumber}
+                        </Text>
+                        <Badge size="sm" variant="light" color={cfg.color}>
+                          {cfg.label}
+                        </Badge>
+                      </Group>
+                      <Text size="sm" c="dimmed" lineClamp={1}>
+                        {chapter.title}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        Cập nhật {timeAgo(chapter.updatedAt)}
+                      </Text>
+                    </Stack>
+                  </Flex>
+                );
+              })}
+            </Stack>
+          </ScrollArea.Autosize>
+
+          <Button
+            color="orange"
+            leftSection={<Plus size={16} />}
+            mt="md"
+            onClick={handleCreateNewChapter}
+            fullWidth
+          >
+            + Chương mới
+          </Button>
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/story/MyStoryCard.tsx
+++ b/src/components/story/MyStoryCard.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import {
   Eye,
   MessageCircle,
@@ -17,10 +18,12 @@ import {
   Send,
   Star,
   Trash2,
+  X,
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import type { Story } from "../../interfaces/Story";
 import { ShorterNumber, timeAgo } from "../../utils";
+import ChaptersListModal from "../author/ChaptersListModal";
 
 const statusConfig: Record<string, { label: string; color: string }> = {
   draft: { label: "Bản nháp", color: "gray" },
@@ -35,15 +38,21 @@ interface MyStoryCardProps {
   story: Story;
   onDelete: (id: string) => void;
   onSubmitReview: (id: string) => void;
+  onUnpublish?: (id: string) => void;
 }
 
 export default function MyStoryCard({
   story,
   onDelete,
   onSubmitReview,
+  onUnpublish,
 }: MyStoryCardProps) {
   const navigate = useNavigate();
   const cfg = statusConfig[story.status] ?? statusConfig.draft;
+  const [
+    chaptersModalOpened,
+    { open: openChaptersModal, close: closeChaptersModal },
+  ] = useDisclosure(false);
 
   return (
     <Flex
@@ -111,11 +120,7 @@ export default function MyStoryCard({
 
       {/* Hành động */}
       <Flex gap="xs" align="center" className="flex-shrink-0">
-        <Button
-          size="sm"
-          color="orange"
-          onClick={() => navigate(`/author/story/${story.slug}/write-chapter`)}
-        >
+        <Button size="sm" color="blue" onClick={openChaptersModal}>
           Tiếp tục viết
         </Button>
 
@@ -126,13 +131,6 @@ export default function MyStoryCard({
             </ActionIcon>
           </Menu.Target>
           <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<Pencil size={14} />}
-              onClick={() => navigate(`/author/edit-story/${story.slug}`)}
-            >
-              Chỉnh sửa
-            </Menu.Item>
-
             {story.status === "draft" && (
               <Menu.Item
                 leftSection={<Send size={14} />}
@@ -144,6 +142,19 @@ export default function MyStoryCard({
 
             <Menu.Divider />
 
+            {story.status === "active" && (
+              <>
+                <Menu.Item
+                  color="red"
+                  leftSection={<X size={14} />}
+                  onClick={() => onUnpublish?.(story._id)}
+                >
+                  Hủy xuất bản
+                </Menu.Item>
+                <Menu.Divider />
+              </>
+            )}
+
             <Menu.Item
               color="red"
               leftSection={<Trash2 size={14} />}
@@ -154,6 +165,14 @@ export default function MyStoryCard({
           </Menu.Dropdown>
         </Menu>
       </Flex>
+
+      <ChaptersListModal
+        opened={chaptersModalOpened}
+        onClose={closeChaptersModal}
+        storyId={story._id}
+        storySlug={story.slug}
+        storyTitle={story.title}
+      />
     </Flex>
   );
 }

--- a/src/components/user/user-navbar/ChangePassword.tsx
+++ b/src/components/user/user-navbar/ChangePassword.tsx
@@ -1,6 +1,7 @@
-import { Button, PasswordInput, Stack, Text } from "@mantine/core";
+import { Button, PasswordInput, Stack, Text, Group } from "@mantine/core";
 import { Lock } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import UserService from "../../../services/UserService";
 import { showError, showSuccess } from "../../../utils/notifications";
 
@@ -15,6 +16,7 @@ interface FieldErrors {
 }
 
 const ChangePassword = () => {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [form, setForm] = useState<ChangePasswordFormState>({
     currentPassword: "",
@@ -111,17 +113,31 @@ const ChangePassword = () => {
 
       <form onSubmit={handleSubmit}>
         <Stack gap="md">
-          <PasswordInput
-            label="Mật khẩu hiện tại"
-            placeholder="Nhập mật khẩu hiện tại"
-            required
-            value={form.currentPassword}
-            onChange={(e) =>
-              handleChange("currentPassword", e.currentTarget.value)
-            }
-            error={errors.currentPassword}
-            disabled={loading}
-          />
+          <div>
+            <Group justify="space-between" align="center" mb="xs">
+              <Text size="sm" fw={500}>
+                Mật khẩu hiện tại <span style={{ color: "red" }}>*</span>
+              </Text>
+              <Text
+                size="sm"
+                c="blue"
+                style={{ cursor: "pointer" }}
+                onClick={() => navigate("/forgot-password")}
+                className="hover:underline"
+              >
+                Quên mật khẩu?
+              </Text>
+            </Group>
+            <PasswordInput
+              placeholder="Nhập mật khẩu hiện tại"
+              value={form.currentPassword}
+              onChange={(e) =>
+                handleChange("currentPassword", e.currentTarget.value)
+              }
+              error={errors.currentPassword}
+              disabled={loading}
+            />
+          </div>
 
           <PasswordInput
             label="Mật khẩu mới"

--- a/src/hooks/useLogoutCleanup.ts
+++ b/src/hooks/useLogoutCleanup.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useUserStore } from "../stores/useUserStore";
+
+/**
+ * Hook để cleanup React Query cache khi user logout
+ * Xóa tất cả reading history, comment history, review history, etc.
+ */
+export const useLogoutCleanup = () => {
+  const queryClient = useQueryClient();
+  const isLoggedIn = useUserStore((state) => state.isLoggedIn);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      // Xóa tất cả history-related queries
+      queryClient.removeQueries({ queryKey: ["readingHistory"] });
+      queryClient.removeQueries({ queryKey: ["last3History"] });
+      queryClient.removeQueries({ queryKey: ["commentHistory"] });
+      queryClient.removeQueries({ queryKey: ["reviewHistory"] });
+      queryClient.removeQueries({ queryKey: ["rechargeHistory"] });
+      queryClient.removeQueries({ queryKey: ["purchaseHistory"] });
+    }
+  }, [isLoggedIn, queryClient]);
+};

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -3,60 +3,64 @@ import { CircleArrowUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Outlet, ScrollRestoration, useNavigate } from "react-router-dom";
 import { setNavigate } from "../lib/navigation";
+import { useLogoutCleanup } from "../hooks/useLogoutCleanup";
 import Footer from "./footer/Footer";
 import Header from "./header/Header";
 
 const Layout = () => {
-	const navigate = useNavigate();
-	useEffect(() => {
-		setNavigate(navigate);
-	}, [navigate]);
+  const navigate = useNavigate();
 
-	const [showScrollTop, setShowScrollTop] = useState(false);
+  // Cleanup cache khi user logout
+  useLogoutCleanup();
+  useEffect(() => {
+    setNavigate(navigate);
+  }, [navigate]);
 
-	useEffect(() => {
-		const handleScroll = () => {
-			setShowScrollTop(window.scrollY > 0);
-		};
+  const [showScrollTop, setShowScrollTop] = useState(false);
 
-		window.addEventListener("scroll", handleScroll);
-		handleScroll(); // Kiểm tra ngay khi load
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 0);
+    };
 
-		return () => {
-			window.removeEventListener("scroll", handleScroll);
-		};
-	}, []);
+    window.addEventListener("scroll", handleScroll);
+    handleScroll(); // Kiểm tra ngay khi load
 
-	return (
-		<AppShell transitionDuration={500} transitionTimingFunction="ease">
-			<ScrollRestoration />
-			{/* Main App */}
-			<AppShell.Main className="flex flex-col min-h-screen bg-white dark:bg-neutral-700">
-				<Header />
-				<div className="flex flex-1 justify-center">
-					<div className="max-w-[1080px] w-full">
-						<Outlet />
-					</div>
-				</div>
-				<Footer />
-			</AppShell.Main>
-			{showScrollTop && (
-				<AppShell.Footer
-					style={{ position: "relative" }}
-					className="fixed bottom-4 right-4 z-50"
-				>
-					<div className="fixed bottom-4 right-4 z-50">
-						<button
-							onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-							className="p-2 rounded-full hover:bg-gray-300 transition"
-						>
-							<CircleArrowUp />
-						</button>
-					</div>
-				</AppShell.Footer>
-			)}
-		</AppShell>
-	);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return (
+    <AppShell transitionDuration={500} transitionTimingFunction="ease">
+      <ScrollRestoration />
+      {/* Main App */}
+      <AppShell.Main className="flex flex-col min-h-screen bg-white dark:bg-neutral-700">
+        <Header />
+        <div className="flex flex-1 justify-center">
+          <div className="max-w-[1080px] w-full">
+            <Outlet />
+          </div>
+        </div>
+        <Footer />
+      </AppShell.Main>
+      {showScrollTop && (
+        <AppShell.Footer
+          style={{ position: "relative" }}
+          className="fixed bottom-4 right-4 z-50"
+        >
+          <div className="fixed bottom-4 right-4 z-50">
+            <button
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+              className="p-2 rounded-full hover:bg-gray-300 transition"
+            >
+              <CircleArrowUp />
+            </button>
+          </div>
+        </AppShell.Footer>
+      )}
+    </AppShell>
+  );
 };
 
 export default Layout;

--- a/src/layouts/header/Header.tsx
+++ b/src/layouts/header/Header.tsx
@@ -232,7 +232,7 @@ const Header = () => {
             {/* Premium Button */}
             <Link
               to="/purchase/spirit-stone"
-              className="hidden lg:flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-100 dark:hover:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg transition-all duration-200 cursor-pointer shadow-sm hover:shadow"
+              className="hidden md:flex items-center gap-1.5 px-4 py-2 text-sm font-semibold text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 hover:bg-blue-100 dark:hover:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg transition-all duration-200 cursor-pointer shadow-sm hover:shadow"
             >
               <CircleDollarSignIcon />
               Nạp linh thạch
@@ -282,7 +282,7 @@ const Header = () => {
                     >
                       <Box className="flex gap-2">
                         <History size={18} />
-                      Lịch sử của tôi
+                        Lịch sử của tôi
                       </Box>
                     </MantineMenu.Item>
                     <MantineMenu.Divider className="border-gray-200 dark:border-gray-700" />
@@ -491,7 +491,8 @@ const Header = () => {
                     >
                       Trang cá nhân
                     </Link>
-                    <Link to="/history"
+                    <Link
+                      to="/history"
                       className="block px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors duration-200 cursor-pointer"
                       onClick={() => setMobileMenuOpen(false)}
                     >

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -4,38 +4,37 @@ import { BASE_URL } from "../constants";
 import { isTokenExpired } from "../utils/token";
 
 export const instance = axios.create({
-	baseURL: BASE_URL,
-	headers: {
-		"Content-Type": "application/json",
-	},
+  baseURL: BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
 });
 
 instance.interceptors.request.use(
-	(config) => {
-		const token = localStorage.getItem("token");
-		if (token && !isTokenExpired(token)) {
-			config.headers.Authorization = `Bearer ${token}`;
-		}
-		return config;
-	},
-	(error) => {
-		return Promise.reject(error);
-	},
+  (config) => {
+    const token = localStorage.getItem("token");
+    if (token && !isTokenExpired(token)) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
 );
 
 instance.interceptors.response.use(
-	(response) => {
-		return response;
-	},
-	(error) => {
-		if (error.response && error.response.status === 401) {
-			console.error(
-				"Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại để tiếp tục.",
-			);
-			localStorage.removeItem("token");
-			localStorage.removeItem("user");
-		}
-		return error.response;
-		
-	},
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      console.error(
+        "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại để tiếp tục.",
+      );
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+    }
+    return Promise.reject(error);
+  },
 );

--- a/src/pages/author/MyStoriesPage.tsx
+++ b/src/pages/author/MyStoriesPage.tsx
@@ -15,12 +15,13 @@ import { BookPlus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import MyStoryCard from "../../components/story/MyStoryCard";
+import ConfirmDeleteModal from "../../components/common/ConfirmDeleteModal";
 import {
   useDeleteStory,
   useMyStories,
   useUpdateStory,
 } from "../../hooks/useStory";
-import { showSuccess } from "../../utils/notifications";
+import { showSuccess, showError } from "../../utils/notifications";
 
 export default function MyStoriesPage() {
   const navigate = useNavigate();
@@ -35,6 +36,10 @@ export default function MyStoriesPage() {
   const [
     reviewModalOpened,
     { open: openReviewModal, close: closeReviewModal },
+  ] = useDisclosure(false);
+  const [
+    unpublishModalOpened,
+    { open: openUnpublishModal, close: closeUnpublishModal },
   ] = useDisclosure(false);
   const [selectedStoryId, setSelectedStoryId] = useState<string | null>(null);
 
@@ -84,6 +89,32 @@ export default function MyStoriesPage() {
     );
   };
 
+  const handleUnpublishClick = (id: string) => {
+    setSelectedStoryId(id);
+    openUnpublishModal();
+  };
+
+  const handleConfirmUnpublish = () => {
+    if (!selectedStoryId) return;
+    updateStory.mutate(
+      { id: selectedStoryId, data: { status: "private" } },
+      {
+        onSuccess: () => {
+          showSuccess("Truyện đã được hủy xuất bản");
+          closeUnpublishModal();
+          setSelectedStoryId(null);
+        },
+        onError: () => {
+          showError("Lỗi khi hủy xuất bản truyện");
+        },
+        onSettled: () => {
+          closeUnpublishModal();
+          setSelectedStoryId(null);
+        },
+      },
+    );
+  };
+
   const renderStoryList = (list: typeof allStories) => {
     if (isLoading) {
       return (
@@ -118,6 +149,7 @@ export default function MyStoriesPage() {
             story={story}
             onDelete={handleDeleteClick}
             onSubmitReview={handleSubmitReviewClick}
+            onUnpublish={handleUnpublishClick}
           />
         ))}
       </Stack>
@@ -130,7 +162,7 @@ export default function MyStoriesPage() {
       <Flex justify="space-between" align="center" mb="lg">
         <Title order={2}>Truyện của tôi</Title>
         <Button
-          color="orange"
+          color="blue"
           leftSection={<BookPlus size={16} />}
           onClick={() => navigate("/author/write-story")}
         >
@@ -206,6 +238,18 @@ export default function MyStoriesPage() {
           </Button>
         </Flex>
       </Modal>
+
+      {/* Modal xác nhận hủy xuất bản */}
+      <ConfirmDeleteModal
+        opened={unpublishModalOpened}
+        onClose={closeUnpublishModal}
+        onConfirm={handleConfirmUnpublish}
+        loading={updateStory.isPending}
+        title="Hủy xuất bản truyện"
+        message='Bạn có chắc muốn hủy xuất bản truyện này? Truyện sẽ chuyển sang trạng thái "Riêng tư" và không thể xuất bản lại.'
+        confirmText="Hủy xuất bản"
+        cancelText="Hủy"
+      />
     </Container>
   );
 }

--- a/src/pages/author/WriteChapterPage.tsx
+++ b/src/pages/author/WriteChapterPage.tsx
@@ -32,7 +32,7 @@ import {
   Check,
 } from "lucide-react";
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { z } from "zod";
 import type { Story } from "../../interfaces/Story";
 import type { Chapter } from "../../interfaces/Chapter";
@@ -75,6 +75,8 @@ function formatDate(dateStr?: string) {
 export default function WriteChapterPage() {
   const navigate = useNavigate();
   const { storySlug } = useParams<{ storySlug: string }>();
+  const [searchParams] = useSearchParams();
+  const chapterParam = searchParams.get("chapter");
   const [story, setStory] = useState<Story | null>(null);
   const [chapters, setChapters] = useState<Chapter[]>([]);
   const [storyLoading, setStoryLoading] = useState(true);
@@ -89,6 +91,7 @@ export default function WriteChapterPage() {
   );
   const [contentError, setContentError] = useState<string | undefined>();
   const [editorInitialContent, setEditorInitialContent] = useState<string>("");
+  const [editorResetKey, setEditorResetKey] = useState(0);
   const [publishModalOpened, setPublishModalOpened] = useState(false);
 
   const form = useForm<WriteChapterFormValues>({
@@ -105,9 +108,13 @@ export default function WriteChapterPage() {
     return Math.max(...chapters.map((c) => c.chapterNumber)) + 1;
   }, [chapters]);
 
+  const generateChapterTitle = (partNumber: number) => {
+    if (story) return `Chương ${partNumber}`;
+  };
+
   // Word count from content
   const wordCount = useMemo(() => {
-    if (!contentPayload || contentPayload.mode !== "editor") return 0;
+    if (!contentPayload) return 0;
     const plain = contentPayload.html.replace(/<[^>]+>/g, " ").trim();
     return plain ? plain.split(/\s+/).filter(Boolean).length : 0;
   }, [contentPayload]);
@@ -123,57 +130,109 @@ export default function WriteChapterPage() {
     return chapterList;
   }, []);
 
+  const handleSelectChapter = useCallback(
+    async (index: number) => {
+      const ch = chapters[index];
+      setSelectedChapterIndex(index);
+      form.setValues({
+        title: ch.title,
+        chapterType: ch.isPremium ? "vip" : "free",
+        price: ch.price || 1,
+      });
+      setContentError(undefined);
+      setSaved(false);
+      setChapterListOpened(false);
+
+      // Fetch chapter content from the server
+      try {
+        const fullChapter = await AuthorService.getChapterById(ch.id);
+        const html = fullChapter.contentURL ?? "";
+        setEditorInitialContent(html);
+        setContentPayload({ mode: "editor", html });
+      } catch {
+        setEditorInitialContent("");
+        setContentPayload(null);
+      }
+    },
+    [chapters, form],
+  );
+
   useEffect(() => {
     if (!storySlug) return;
     setStoryLoading(true);
     AuthorService.getStoryBySlug(storySlug)
       .then((data) => {
         setStory(data);
-        return loadChapters(data._id);
+        return loadChapters(data._id).then((chapterList) => ({
+          story: data,
+          chapters: chapterList,
+        }));
+      })
+      .then(async ({ chapters: chapterList }) => {
+        // Select chapter from URL param, or start in new-chapter mode if no param
+        const targetNumber = chapterParam ? Number(chapterParam) : null;
+        const targetIdx =
+          targetNumber !== null
+            ? chapterList.findIndex((c) => c.chapterNumber === targetNumber)
+            : -1;
+        const idx = targetIdx !== -1 ? targetIdx : -1;
+
+        if (idx === -1) {
+          // No matching chapter or no param → new chapter mode, auto-fill title
+          const nextNum =
+            chapterList.length === 0
+              ? 1
+              : Math.max(...chapterList.map((c) => c.chapterNumber)) + 1;
+          form.setValues({
+            title: `Chương ${nextNum}`,
+            chapterType: "free",
+            price: 1,
+          });
+          return;
+        }
+
+        const ch = chapterList[idx];
+        setSelectedChapterIndex(idx);
+        form.setValues({
+          title: ch.title,
+          chapterType: ch.isPremium ? "vip" : "free",
+          price: ch.price || 1,
+        });
+        setContentError(undefined);
+        setSaved(false);
+        setChapterListOpened(false);
+
+        // Fetch chapter content from the server
+        try {
+          const fullChapter = await AuthorService.getChapterById(ch.id);
+          const html = fullChapter.contentURL ?? "";
+          setEditorInitialContent(html);
+          setContentPayload({ mode: "editor", html });
+        } catch {
+          setEditorInitialContent("");
+          setContentPayload(null);
+        }
       })
       .catch(() => {
         showError("Không thể tải thông tin tác phẩm");
         navigate(-1);
       })
       .finally(() => setStoryLoading(false));
-  }, [storySlug, loadChapters, navigate]);
+  }, [storySlug, chapterParam, loadChapters, navigate]);
 
   const handleNewPart = () => {
     setSelectedChapterIndex(null);
     form.setValues({
-      title: `Chương ${nextChapterNumber}`,
+      title: generateChapterTitle(nextChapterNumber),
       chapterType: "free",
       price: 1,
     });
     setEditorInitialContent("");
+    setEditorResetKey((k) => k + 1);
     setContentPayload(null);
     setContentError(undefined);
     setSaved(false);
     setChapterListOpened(false);
-  };
-
-  const handleSelectChapter = async (index: number) => {
-    const ch = chapters[index];
-    setSelectedChapterIndex(index);
-    form.setValues({
-      title: ch.title,
-      chapterType: ch.isPremium ? "vip" : "free",
-      price: ch.price || 1,
-    });
-    setContentError(undefined);
-    setSaved(false);
-    setChapterListOpened(false);
-
-    // Fetch chapter content from the server
-    try {
-      const fullChapter = await AuthorService.getChapterById(ch.id);
-      const html = fullChapter.contentURL ?? "";
-      setEditorInitialContent(html);
-      setContentPayload({ mode: "editor", html });
-    } catch {
-      setEditorInitialContent("");
-      setContentPayload(null);
-    }
   };
 
   const buildFormData = (
@@ -186,12 +245,12 @@ export default function WriteChapterPage() {
       setContentError("Vui lòng nhập nội dung chương");
       return null;
     }
-    if (contentPayload.mode === "editor") {
+    if (status === "pending" && contentPayload.mode === "editor") {
       const plain = contentPayload.html.replace(/<[^>]+>/g, " ").trim();
       const wc = plain ? plain.split(/\s+/).filter(Boolean).length : 0;
       if (wc < 50) {
         setContentError(
-          `Nội dung chương phải có ít nhất 50 từ (hiện tại: ${wc} từ)`,
+          `Nội dung chương phải có ít nhất 50 từ để đăng (hiện tại: ${wc} từ)`,
         );
         return null;
       }
@@ -211,12 +270,8 @@ export default function WriteChapterPage() {
     formData.append("title", values.title);
     formData.append("status", status);
 
-    if (contentPayload.mode === "editor") {
-      const blob = new Blob([contentPayload.html], { type: "text/html" });
-      formData.append("file", blob, `${values.title}.html`);
-    } else {
-      formData.append("file", contentPayload.file);
-    }
+    const blob = new Blob([contentPayload.html], { type: "text/html" });
+    formData.append("file", blob, `${values.title}.html`);
 
     formData.append("chapterType", values.chapterType);
 
@@ -310,7 +365,7 @@ export default function WriteChapterPage() {
   }
 
   return (
-    <Box className="min-h-screen bg-[#f3f3f3]">
+    <Box className="bg-[#f3f3f3]">
       {/* ── Header ── */}
       <Box
         style={{
@@ -406,6 +461,33 @@ export default function WriteChapterPage() {
                         </Group>
                       ))}
 
+                      {/* Virtual entry for unsaved new chapter */}
+                      {selectedChapterIndex === null && (
+                        <Group
+                          justify="space-between"
+                          px="md"
+                          py="sm"
+                          style={{
+                            backgroundColor: "#f0f9ff",
+                            borderBottom: "1px solid #f0f0f0",
+                          }}
+                        >
+                          <Stack gap={2}>
+                            <Text size="sm" fw={500} lineClamp={1}>
+                              {form.values.title ||
+                                `Chương ${nextChapterNumber}`}
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                              Bản nháp - Chưa lưu
+                            </Text>
+                          </Stack>
+                          <Check
+                            size={18}
+                            color="var(--mantine-color-teal-6)"
+                          />
+                        </Group>
+                      )}
+
                       <Box px="md" py="sm">
                         <Button
                           fullWidth
@@ -448,7 +530,7 @@ export default function WriteChapterPage() {
             {/* Right: Action buttons */}
             <Group gap="xs">
               <Button
-                color="orange"
+                color="blue"
                 size="sm"
                 loading={loading}
                 leftSection={<Send size={14} />}
@@ -544,6 +626,7 @@ export default function WriteChapterPage() {
             {/* Chapter content editor */}
             <Box className="bg-white rounded-lg border border-gray-200" p="md">
               <ChapterContentInput
+                key={editorResetKey}
                 onChange={(payload) => {
                   setContentPayload(payload);
                   if (payload) setContentError(undefined);

--- a/src/pages/author/WriteStoryPage.tsx
+++ b/src/pages/author/WriteStoryPage.tsx
@@ -2,12 +2,14 @@ import {
   ActionIcon,
   Box,
   Button,
+  Combobox,
   Container,
   Divider,
   FileButton,
   Grid,
   Group,
   Image,
+  MenuDropdown,
   Paper,
   Select,
   Stack,
@@ -18,17 +20,24 @@ import {
   TextInput,
   Title,
   UnstyledButton,
+  useMantineColorScheme,
+  useMantineTheme,
 } from "@mantine/core";
 import { ArrowLeft, ImageIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { Topic } from "../../interfaces/Topic";
+import { useUserStore } from "../../stores/useUserStore";
 import { AuthorService } from "../../services/AuthorService";
 import { TopicService } from "../../services/TopicService";
 import { showError, showSuccess } from "../../utils/notifications.tsx";
 
 export default function WriteStoryPage() {
   const navigate = useNavigate();
+  const { updateUser } = useUserStore();
+  const theme = useMantineTheme();
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === "dark";
   const [topics, setTopics] = useState<Topic[]>([]);
   const [coverImage, setCoverImage] = useState<File | null>(null);
   const [coverPreview, setCoverPreview] = useState<string | null>(null);
@@ -126,9 +135,13 @@ export default function WriteStoryPage() {
       }
 
       const story = await AuthorService.createStory(formData);
+
+      // Update user role to author
+      updateUser({ role: "author" });
+
       showSuccess(
         "Tác phẩm đã được tạo. Bắt đầu viết chương đầu tiên!",
-        "Tạo tác phẩm thành công",
+        "Tạo truyện thành công",
       );
       navigate(`/author/story/${story.slug}/write-chapter`);
     } catch {
@@ -143,17 +156,25 @@ export default function WriteStoryPage() {
     : [];
 
   return (
-    <Box className="min-h-screen bg-[#f3f3f3]">
+    <Box
+      style={{
+        backgroundColor: (isDark
+          ? theme.colors.dark[8]
+          : theme.colors.gray[0]) as string,
+      }}
+    >
       {/* ── Header ── */}
       <Box
         style={{
-          borderBottom: "1px solid #dfdfdf",
-          backgroundColor: "white",
+          borderBottom: `1px solid ${isDark ? theme.colors.dark[6] : theme.colors.gray[2]}`,
+          backgroundColor: (isDark
+            ? theme.colors.dark[7]
+            : theme.colors.white) as string,
         }}
       >
         <Container size="xl" py="sm">
-          <Group justify="space-between" align="center">
-            <Group align="center" gap="sm">
+          <Group justify="space-between" align="center" wrap="wrap">
+            <Group align="center" gap="sm" wrap="nowrap">
               <ActionIcon
                 variant="subtle"
                 size="lg"
@@ -162,25 +183,40 @@ export default function WriteStoryPage() {
               >
                 <ArrowLeft size={20} />
               </ActionIcon>
-              <Stack gap={0}>
+              <Stack gap={0} style={{ minWidth: 0, flex: 1 }}>
                 <Text size="xs" c="dimmed">
-                  Thêm thông tin tác phẩm
+                  Thêm thông tin truyện
                 </Text>
-                <Title order={3} size="h4" fw={600}>
+                <Title
+                  order={3}
+                  size="h4"
+                  fw={600}
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
                   {title || "Tác phẩm chưa đặt tên"}
                 </Title>
               </Stack>
             </Group>
 
-            <Group gap="xs">
+            <Group gap="xs" wrap="wrap">
               <Button
                 variant="subtle"
                 color="gray"
                 onClick={() => navigate("/author/my-stories")}
+                size="sm"
               >
                 Hủy
               </Button>
-              <Button color="orange" loading={loading} onClick={handleContinue}>
+              <Button
+                color="blue"
+                loading={loading}
+                onClick={handleContinue}
+                size="sm"
+              >
                 Tiếp tục
               </Button>
             </Group>
@@ -189,9 +225,21 @@ export default function WriteStoryPage() {
       </Box>
 
       {/* ── Body ── */}
-      <Container size="xl" py="xl">
-        <Paper withBorder p={{ base: "md", md: "xl" }} radius="sm" bg="white">
-          <Grid gutter="xl" align="start">
+      <Container size="xl" py="md">
+        <Paper
+          withBorder
+          p={{ base: "md", md: "lg" }}
+          radius="sm"
+          style={{
+            backgroundColor: (isDark
+              ? theme.colors.dark[7]
+              : theme.colors.white) as string,
+            borderColor: (isDark
+              ? theme.colors.dark[6]
+              : theme.colors.gray[2]) as string,
+          }}
+        >
+          <Grid gutter="lg" align="start">
             {/* Left: Cover image */}
             <Grid.Col span={{ base: 12, md: 4 }}>
               <Stack align="center" gap="xs">
@@ -215,13 +263,17 @@ export default function WriteStoryPage() {
                         aspectRatio: "2 / 3",
                         borderRadius: 2,
                         overflow: "hidden",
-                        background: "#ececec",
+                        background: (isDark
+                          ? theme.colors.dark[6]
+                          : "#ececec") as string,
                         border: coverError
-                          ? "1.5px solid var(--mantine-color-red-6)"
-                          : "1px solid #d5d5d5",
+                          ? `1.5px solid ${theme.colors.red[6]}`
+                          : `1px solid ${isDark ? theme.colors.dark[5] : theme.colors.gray[3]}`,
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
+                        cursor: "pointer",
+                        transition: "all 0.2s ease",
                       }}
                     >
                       {coverPreview ? (
@@ -241,7 +293,9 @@ export default function WriteStoryPage() {
                               width: 48,
                               height: 48,
                               borderRadius: 6,
-                              background: "#7d7d7d",
+                              background: (isDark
+                                ? theme.colors.dark[5]
+                                : "#7d7d7d") as string,
                               display: "flex",
                               alignItems: "center",
                               justifyContent: "center",
@@ -282,11 +336,15 @@ export default function WriteStoryPage() {
               <Stack gap={0}>
                 <Box pb="sm">
                   <Text fw={600} size="md">
-                    Thông tin tác phẩm
+                    Thông tin truyện
                   </Text>
                   <Box
                     mt={8}
-                    style={{ width: 122, height: 3, background: "#f97316" }}
+                    style={{
+                      width: 122,
+                      height: 3,
+                      background: theme.colors.blue[6] as string,
+                    }}
                   />
                 </Box>
 
@@ -302,7 +360,7 @@ export default function WriteStoryPage() {
                       </Text>
                     </Text>
                     <TextInput
-                      placeholder="Nhập tiêu đề tác phẩm"
+                      placeholder="Nhập tiêu đề truyện"
                       radius={2}
                       value={title}
                       onChange={(e) => {
@@ -348,8 +406,6 @@ export default function WriteStoryPage() {
                     <Select
                       placeholder="Chọn thể loại"
                       data={topicOptions}
-                      searchable
-                      clearable
                       radius={2}
                       value={category}
                       onChange={(val) => {
@@ -368,11 +424,13 @@ export default function WriteStoryPage() {
                       Thẻ (Tags)
                     </Text>
                     <TagsInput
-                      placeholder="Thêm thẻ"
+                      placeholder="Thêm tag bằng cách ấn Enter, hỗ trợ thêm tối đa 25 tags"
                       maxTags={25}
                       radius={2}
                       value={tags}
                       onChange={setTags}
+                      acceptValueOnBlur
+                      data={topics.map((t) => t.name)}
                     />
                   </Box>
 
@@ -382,7 +440,7 @@ export default function WriteStoryPage() {
                   <Box>
                     <Group justify="space-between" align="center" mb={4}>
                       <Text fw={600} size="sm">
-                        Có phải trả phí
+                        Có trả phí hay không?
                       </Text>
                       <Switch
                         checked={isPremium}

--- a/src/routes/author/index.tsx
+++ b/src/routes/author/index.tsx
@@ -1,9 +1,46 @@
 import { type RouteObject } from "react-router-dom";
 import Layout from "../../layouts/Layout";
 import { RoleBasedRoute } from "../../components/common/RoleBasedRoute";
+import { ProtectedRoute } from "../../components/common/ProtectedRoute";
 import WriteStoryPage from "../../pages/author/WriteStoryPage";
 import WriteChapterPage from "../../pages/author/WriteChapterPage";
 import MyStoriesPage from "../../pages/author/MyStoriesPage";
+
+// Allow users to start writing a story (they will become an author after creating the story)
+// Only requires authentication, no role check
+export const UserWriteStoryRoute: RouteObject = {
+  path: "/author/write-story",
+  element: <Layout />,
+  children: [
+    {
+      element: <ProtectedRoute />,
+      children: [
+        {
+          index: true,
+          element: <WriteStoryPage />,
+        },
+      ],
+    },
+  ],
+};
+
+// My Stories route - requires authentication but accessible to any user
+// (they can view their own stories regardless of current role)
+export const MyStoriesRoute: RouteObject = {
+  path: "/author/my-stories",
+  element: <Layout />,
+  children: [
+    {
+      element: <ProtectedRoute />,
+      children: [
+        {
+          index: true,
+          element: <MyStoriesPage />,
+        },
+      ],
+    },
+  ],
+};
 
 export const AuthorRoute: RouteObject = {
   path: "/author",
@@ -17,14 +54,6 @@ export const AuthorRoute: RouteObject = {
     {
       element: <Layout />,
       children: [
-        {
-          path: "my-stories",
-          element: <MyStoriesPage />,
-        },
-        {
-          path: "write-story",
-          element: <WriteStoryPage />,
-        },
         {
           path: "story/:storySlug/write-chapter",
           element: <WriteChapterPage />,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -12,7 +12,7 @@ import StoryDetailPage from "../pages/story-detail-page/StoryDetailPage";
 import UserProfile from "../pages/user-profile/UserProfile";
 import VerifyEmailPage from "../pages/verify-email-page/VerifyEmailPage";
 import { AdminRoute } from "./admin";
-import { AuthorRoute } from "./author";
+import { AuthorRoute, UserWriteStoryRoute, MyStoriesRoute } from "./author";
 import ForgotPasswordPage from "../pages/forgot-password/ForgotPasswordPage";
 import ResetPasswordPage from "../pages/reset-password/ResetPasswordPage";
 import ChapterPage from "../pages/chapter-page/ChapterPage";
@@ -22,6 +22,8 @@ import HistoryPage from "../pages/history-page/HistoryPage";
 import NotificationPage from "../pages/notification-page/NotificationPage";
 
 const routes = createBrowserRouter([
+  UserWriteStoryRoute,
+  MyStoriesRoute,
   AdminRoute,
   AuthorRoute,
   {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -177,7 +177,14 @@ const UserService = {
     try {
       const response = await instance.post("/auth/login", credentials);
       // Extract data from wrapper
-      const { success, data } = response.data;
+      const { success, data, message } = response.data;
+
+      if (!data || !data.accessToken) {
+        throw new Error(
+          message || "Không nhận được thông tin đăng nhập từ server",
+        );
+      }
+
       return {
         success,
         accessToken: data.accessToken,
@@ -186,7 +193,8 @@ const UserService = {
     } catch (error: unknown) {
       console.error("Lỗi đăng nhập:", error);
       if (axios.isAxiosError(error) && error.response) {
-        throw error.response?.data || error.message;
+        const errorData = error.response.data as any;
+        throw new Error(errorData?.message || "Đăng nhập thất bại");
       }
       throw error instanceof Error
         ? error.message
@@ -220,7 +228,14 @@ const UserService = {
         rememberMe,
       });
       // Extract data from wrapper
-      const { success, data } = response.data;
+      const { success, data, message } = response.data;
+
+      if (!data || !data.accessToken) {
+        throw new Error(
+          message || "Không nhận được thông tin đăng nhập từ server",
+        );
+      }
+
       return {
         success,
         accessToken: data.accessToken,
@@ -228,7 +243,8 @@ const UserService = {
       };
     } catch (error: unknown) {
       if (axios.isAxiosError(error) && error.response) {
-        throw error.response?.data || error;
+        const errorData = error.response.data as any;
+        throw new Error(errorData?.message || "Đăng nhập Google thất bại");
       }
       throw error instanceof Error
         ? error.message
@@ -322,9 +338,7 @@ const UserService = {
     return res.data.data;
   },
 
-  async toggleFollow(
-    authorId: string
-  ): Promise<{
+  async toggleFollow(authorId: string): Promise<{
     status: "follow" | "unfollow";
     relationship: UserRelationship;
   }> {
@@ -332,7 +346,10 @@ const UserService = {
     return res.data.data;
   },
 
-  async getFollowers(authorId: string, page = 1): Promise<{
+  async getFollowers(
+    authorId: string,
+    page = 1,
+  ): Promise<{
     followers: AuthorPublicProfile[];
     total: number;
     page: number;
@@ -344,7 +361,10 @@ const UserService = {
     return res.data.data;
   },
 
-  async getFollowing(authorId: string, page = 1): Promise<{
+  async getFollowing(
+    authorId: string,
+    page = 1,
+  ): Promise<{
     following: AuthorPublicProfile[];
     total: number;
     page: number;
@@ -383,7 +403,9 @@ const UserService = {
     if (!query || query.trim() === "") return [];
 
     try {
-      const res = await axiosClient.get("/user/search", { params: { q: query } });
+      const res = await axiosClient.get("/user/search", {
+        params: { q: query },
+      });
 
       const mapped: AuthorPublicProfile[] = res.data.data.map((u: any) => ({
         _id: u.id || u._id,
@@ -413,7 +435,7 @@ const UserService = {
       console.error("Error searching users:", error);
       throw error;
     }
-  }
+  },
 };
 
 export default UserService;

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,14 +1,14 @@
 // src/stores/useUserStore.ts
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export interface UserProfile {
   id: string;
   email: string;
   username: string;
   fullName: string;
-  role: 'admin' | 'author' | 'user';
-  status: 'active' | 'inactive' | 'banned';
+  role: "admin" | "author" | "user";
+  status: "active" | "inactive" | "banned";
   avatarURL?: string;
   backgroundURL?: string;
   vipLevel: number;
@@ -49,7 +49,7 @@ export const useUserStore = create<UserState>()(
           user: state.user ? { ...state.user, ...data } : null,
         })),
       logout: () => {
-        localStorage.removeItem('token');
+        localStorage.removeItem("token");
         set(() => ({
           user: null,
           isLoggedIn: false,
@@ -57,7 +57,7 @@ export const useUserStore = create<UserState>()(
       },
     }),
     {
-      name: 'user-store',
+      name: "user-store",
     },
   ),
 );


### PR DESCRIPTION
Add a ChaptersListModal component for authors and wire it into MyStoryCard to list/select/create chapters; add an unpublish action and confirmation modal in MyStoriesPage. Introduce useLogoutCleanup hook to clear history-related React Query caches on logout and call it from Layout. Simplify ChapterContentInput by removing file-upload mode and Dropzone, keeping editor-only flow and adjusting word/count UI. Improve WriteChapterPage: support ?chapter= URL param, auto-generate titles for new chapters, fetch chapter content when selecting, add editor reset key, enforce 50-word validation only when publishing, and simplify form file handling. Misc UI/UX tweaks: ChangePassword adds a "Forgot password" link, WriteStoryPage updates theme/dark styling and sets user role to author after creation, header/responsive class tweaks, and fix axios interceptor to properly reject on response errors.