### PR TITLE
Enhance chapter statuses, navigation, and pagination in My Stories

### DIFF
--- a/src/components/author/ChaptersListModal.tsx
+++ b/src/components/author/ChaptersListModal.tsx
@@ -11,7 +11,7 @@ import {
   Title,
 } from "@mantine/core";
 import { Plus } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useState } from "react";
 import type { Chapter } from "../../interfaces/Chapter";
 import { useChaptersByStoryForAuthor } from "../../hooks/useChapter";
@@ -32,6 +32,9 @@ const statusConfig: Record<string, { label: string; color: string }> = {
   draft: { label: "Bản nháp", color: "gray" },
   pending: { label: "Chờ duyệt", color: "yellow" },
   active: { label: "Đã duyệt", color: "green" },
+  inactive: { label: "Không hoạt động", color: "gray" },
+  private: { label: "Riêng tư", color: "blue" },
+  error: { label: "Lỗi", color: "orange" },
   rejected: { label: "Bị từ chối", color: "red" },
   banned: { label: "Bị cấm", color: "red.9" },
 };
@@ -44,6 +47,7 @@ export default function ChaptersListModal({
   storyTitle,
 }: ChaptersListModalProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user, updateUser } = useUserStore();
   const [isCreating, setIsCreating] = useState(false);
   const {
@@ -58,8 +62,10 @@ export default function ChaptersListModal({
       updateUser({ role: "author" });
     }
     onClose();
+    // Build return URL with current location
+    const returnTo = `${location.pathname}${location.search}`;
     navigate(
-      `/author/story/${storySlug}/write-chapter?chapter=${chapterNumber}`,
+      `/author/story/${storySlug}/write-chapter?chapter=${chapterNumber}&returnTo=${encodeURIComponent(returnTo)}`,
     );
   };
 
@@ -129,7 +135,7 @@ export default function ChaptersListModal({
         <Stack align="center" py="xl" gap="md">
           <Text c="dimmed">Chưa có chương nào</Text>
           <Button
-            color="orange"
+            color="blue"
             leftSection={isCreating ? <Loader size={14} /> : <Plus size={16} />}
             onClick={handleCreateNewChapter}
             disabled={isCreating}

--- a/src/hooks/useStory.ts
+++ b/src/hooks/useStory.ts
@@ -51,10 +51,11 @@ export const useCreateStory = () => {
   });
 };
 
-export const useMyStories = () => {
+export const useMyStories = (page: number = 1, limit: number = 10) => {
   return useQuery({
-    queryKey: ["my-stories"],
-    queryFn: () => StoryService.getMyStories(),
+    queryKey: ["my-stories", page, limit],
+    queryFn: () => AuthorService.getMyStories(page, limit),
+    placeholderData: keepPreviousData,
   });
 };
 
@@ -114,24 +115,19 @@ export const useStoryDetailWithAuthor = (slug: string) =>
     return res.data;
   });
 
-  export const useAllStory = () => {
-    return useQuery({
-      queryKey: ["allStory"],
-      queryFn: () => StoryService.getAllStory(),
-    });
-  };
+export const useAllStory = () => {
+  return useQuery({
+    queryKey: ["allStory"],
+    queryFn: () => StoryService.getAllStory(),
+  });
+};
 
-  export const useRateStory = (slug?: string) => {
+export const useRateStory = (slug?: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
-      storyId,
-      rate,
-    }: {
-      storyId: string;
-      rate: number;
-    }) => StoryService.rateStory(storyId, rate),
+    mutationFn: ({ storyId, rate }: { storyId: string; rate: number }) =>
+      StoryService.rateStory(storyId, rate),
 
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["story", slug] });

--- a/src/interfaces/Chapter.ts
+++ b/src/interfaces/Chapter.ts
@@ -8,7 +8,15 @@ export interface Chapter {
   isPremium: boolean;
   price: number;
   contentURL?: string;
-  status?: "draft" | "active" | "inactive" | "pending" | "rejected" | "banned";
+  status?:
+    | "draft"
+    | "active"
+    | "inactive"
+    | "error"
+    | "pending"
+    | "rejected"
+    | "banned"
+    | "private";
   views?: number;
   createdAt?: string;
   updatedAt?: string;

--- a/src/pages/author/MyStoriesPage.tsx
+++ b/src/pages/author/MyStoriesPage.tsx
@@ -9,6 +9,8 @@ import {
   Text,
   Title,
   Flex,
+  Pagination,
+  Group,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { BookPlus } from "lucide-react";
@@ -28,7 +30,13 @@ export default function MyStoriesPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = searchParams.get("tab") ?? "published";
-  const { data: stories, isLoading } = useMyStories();
+  const page = Number(searchParams.get("page")) || 1;
+  const LIMIT = 10;
+
+  const { data: responseData, isLoading } = useMyStories(page, LIMIT);
+  const stories = responseData?.stories ?? [];
+  const total = responseData?.total ?? 0;
+
   const deleteStory = useDeleteStory();
   const updateStory = useUpdateStory();
   const { user, updateUser } = useUserStore();
@@ -54,13 +62,18 @@ export default function MyStoriesPage() {
     }
   }, [stories, user?.role, updateUser]);
 
-  // Filter stories theo tab
+  // Filter stories theo tab (từ current page)
   const publishedStories = useMemo(
     () => stories?.filter((s) => s.status === "active") ?? [],
     [stories],
   );
 
   const allStories = useMemo(() => stories ?? [], [stories]);
+
+  // Calculate pagination based on active tab
+  const displayedTotal =
+    activeTab === "published" ? publishedStories.length : total;
+  const displayedTotalPages = Math.ceil(displayedTotal / LIMIT) || 1;
 
   const handleDeleteClick = (id: string) => {
     setSelectedStoryId(id);
@@ -126,6 +139,14 @@ export default function MyStoriesPage() {
     );
   };
 
+  const handlePageChange = (newPage: number) => {
+    setSearchParams(
+      { tab: activeTab, page: newPage.toString() },
+      { replace: true },
+    );
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const renderStoryList = (list: typeof allStories) => {
     if (isLoading) {
       return (
@@ -185,7 +206,10 @@ export default function MyStoriesPage() {
       <Tabs
         value={activeTab}
         onChange={(value) =>
-          setSearchParams({ tab: value ?? "published" }, { replace: true })
+          setSearchParams(
+            { tab: value ?? "published", page: "1" },
+            { replace: true },
+          )
         }
       >
         <Tabs.List mb="md">
@@ -203,6 +227,18 @@ export default function MyStoriesPage() {
           </Tabs.Panel>
           <Tabs.Panel value="all">{renderStoryList(allStories)}</Tabs.Panel>
         </Box>
+
+        {/* Pagination */}
+        {displayedTotal > 0 && (
+          <Group justify="center" mt="lg">
+            <Pagination
+              value={page}
+              onChange={handlePageChange}
+              total={displayedTotalPages}
+              size="sm"
+            />
+          </Group>
+        )}
       </Tabs>
 
       {/* Modal xác nhận xóa */}

--- a/src/pages/author/WriteChapterPage.tsx
+++ b/src/pages/author/WriteChapterPage.tsx
@@ -18,7 +18,6 @@
   TextInput,
   ScrollArea,
   Title,
-  Alert,
 } from "@mantine/core";
 import {
   ChapterContentInput,
@@ -28,6 +27,7 @@ import { useForm } from "@mantine/form";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import {
   ChevronDown,
+  ChevronLeft,
   Send,
   Save,
   MoreVertical,
@@ -36,7 +36,12 @@ import {
   Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState, useCallback, useRef } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  useNavigate,
+  useParams,
+  useSearchParams,
+  useLocation,
+} from "react-router-dom";
 import { z } from "zod";
 import type { Story } from "../../interfaces/Story";
 import type { Chapter } from "../../interfaces/Chapter";
@@ -65,15 +70,22 @@ const statusConfig: Record<string, { label: string; color: string }> = {
   draft: { label: "Bản nháp", color: "gray" },
   pending: { label: "Chờ duyệt", color: "yellow" },
   active: { label: "Đã duyệt", color: "green" },
+  inactive: { label: "Không hoạt động", color: "gray" },
+  private: { label: "Riêng tư", color: "blue" },
+  error: { label: "Lỗi", color: "orange" },
   rejected: { label: "Bị từ chối", color: "red" },
   banned: { label: "Bị cấm", color: "red.9" },
 };
 
 export default function WriteChapterPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { storySlug } = useParams<{ storySlug: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const chapterParam = searchParams.get("chapter");
+  const returnTo =
+    searchParams.get("returnTo") ||
+    (location.state?.returnTo as string | undefined);
   const [story, setStory] = useState<Story | null>(null);
   const [chapters, setChapters] = useState<Chapter[]>([]);
   const [storyLoading, setStoryLoading] = useState(true);
@@ -175,7 +187,7 @@ export default function WriteChapterPage() {
           chapters: chapterList,
         }));
       })
-      .then(async ({ story: storyData, chapters: chapterList }) => {
+      .then(async ({ chapters: chapterList }) => {
         // Select chapter from URL param, or start in new-chapter mode if no param
         const parsedParam = chapterParam ? Number(chapterParam) : null;
         const isValidParam =
@@ -718,6 +730,16 @@ export default function WriteChapterPage() {
           <Group justify="space-between" align="center">
             {/* Left: Back + Story info + Chapter dropdown */}
             <Group align="center" gap="sm">
+              {/* Back button */}
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                onClick={() => navigate(-1)}
+                title="Quay lại"
+              >
+                <ChevronLeft size={20} />
+              </ActionIcon>
+
               {/* Story thumbnail */}
               {story?.image && (
                 <Image
@@ -977,8 +999,13 @@ export default function WriteChapterPage() {
               onClick={() => {
                 isExitingRef.current = true;
                 setUnsavedExitModalOpened(false);
-                // Go back past all pushed dummy states + 1 to reach the actual previous page
-                window.history.go(-(extraPushesRef.current + 1));
+                // If returnTo URL is available, use it; otherwise fall back to history.go()
+                if (returnTo) {
+                  navigate(returnTo, { replace: true });
+                } else {
+                  // Go back past all pushed dummy states + 1 to reach the actual previous page
+                  window.history.go(-(extraPushesRef.current + 1));
+                }
               }}
             >
               Thoát không lưu

--- a/src/pages/author/WriteStoryPage.tsx
+++ b/src/pages/author/WriteStoryPage.tsx
@@ -154,7 +154,9 @@ export default function WriteStoryPage() {
         "Tác phẩm đã được tạo. Bắt đầu viết chương đầu tiên!",
         "Tạo truyện thành công",
       );
-      navigate(`/author/story/${story.slug}/write-chapter?chapter=1`);
+      navigate(
+        `/author/story/${story.slug}/write-chapter?chapter=1&returnTo=${encodeURIComponent("/author/my-stories?tab=all")}`,
+      );
     } catch {
       showError("Có lỗi xảy ra khi tạo truyện. Vui lòng thử lại.");
     } finally {

--- a/src/pages/story-detail-page/StoryDetailPage.tsx
+++ b/src/pages/story-detail-page/StoryDetailPage.tsx
@@ -231,15 +231,18 @@ const StoryDetailPage: FC = () => {
     });
   };
 
-  const { data: rawChapters, isLoading: chapterLoading } =
-    useChaptersByStory(storyId);
-
   const [hoverRating, setHoverRating] = useState<number | null>(null);
   const [loginModalOpened, setLoginModalOpened] = useState(false);
 
+  // Calculate isAuthor early to determine which chapter endpoint to use
   const authorIdFromStory = getAuthorId(story);
   const isAuthor =
     !!user && !!authorIdFromStory && authorIdFromStory === user.id;
+
+  // Only call public endpoint if NOT author; author calls dedicated endpoint
+  const { data: rawChapters, isLoading: chapterLoading } = useChaptersByStory(
+    isAuthor ? "" : storyId,
+  );
 
   const { data: rawAuthorChapters, isLoading: authorChapterLoading } =
     useChaptersByStoryForAuthor(isAuthor ? storyId : "");
@@ -593,7 +596,13 @@ const StoryDetailPage: FC = () => {
                         ? "gray"
                         : chapter.status === "pending"
                           ? "yellow"
-                          : "red"
+                          : chapter.status === "inactive"
+                            ? "gray"
+                            : chapter.status === "private"
+                              ? "blue"
+                              : chapter.status === "error"
+                                ? "orange"
+                                : "red"
                     }
                     variant="light"
                   >
@@ -601,9 +610,17 @@ const StoryDetailPage: FC = () => {
                       ? "Bản nháp"
                       : chapter.status === "pending"
                         ? "Chờ duyệt"
-                        : chapter.status === "rejected"
-                          ? "Từ chối"
-                          : chapter.status}
+                        : chapter.status === "inactive"
+                          ? "Không hoạt động"
+                          : chapter.status === "private"
+                            ? "Riêng tư"
+                            : chapter.status === "error"
+                              ? "Lỗi"
+                              : chapter.status === "rejected"
+                                ? "Từ chối"
+                                : chapter.status === "banned"
+                                  ? "Bị cấm"
+                                  : chapter.status}
                   </Badge>
                 )}
               </Group>

--- a/src/services/AuthorService.ts
+++ b/src/services/AuthorService.ts
@@ -10,8 +10,18 @@ export const AuthorService = {
     return response.data;
   },
 
-  getMyStories: async (): Promise<Story[]> => {
-    const response = await axios.get("/story/my-stories");
+  getMyStories: async (
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<{
+    stories: Story[];
+    total: number;
+    offset: number;
+    limit: number;
+  }> => {
+    const response = await axios.get("/story/my-stories", {
+      params: { page, limit },
+    });
     return response.data;
   },
 


### PR DESCRIPTION
Introduce additional chapter statuses and UI mappings, add navigation return handling, and enable paginated "My Stories".

- Expand Chapter.status union (add: inactive, private, error) and update badge color/labels across components.
- ChaptersListModal & WriteChapterPage: capture current location and propagate a returnTo param when creating/opening chapters; WriteChapterPage reads returnTo, adds a back ActionIcon, and navigates back to returnTo (fallbacks to history.go).
- WriteStoryPage: include returnTo when navigating to first chapter after story creation.
- MyStoriesPage: support pagination via page/search params, render Pagination, and compute totals; useMyStories now accepts page & limit.
- useStory hook: change useMyStories to accept page/limit, adjust queryKey and queryFn; minor formatting/cleanup in other hooks.
- AuthorService.getMyStories: switched to paginated API (page, limit) and returns { stories, total, offset, limit }.
- StoryDetailPage: select public vs author chapter endpoint based on isAuthor and update badge color/label logic for new statuses.

These changes enable richer chapter states, better navigation flow when creating/editing chapters, and paginated listing for authors.