### PR TITLE
feat(admin): add per-item AI analysis loading states and error handling

### DIFF
--- a/src/hooks/useAdminCensor.ts
+++ b/src/hooks/useAdminCensor.ts
@@ -138,7 +138,16 @@ export const useAnalyzeStory = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => AdminCensorService.analyzeStory(id),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      // Check if there's an error in the analysis response
+      if (data.analysis.error) {
+        notifications.show({
+          title: "Lỗi phân tích AI",
+          message: data.analysis.error,
+          color: "red",
+        });
+        return;
+      }
       // Invalidate pending stories to refresh with AI data
       queryClient.invalidateQueries({
         queryKey: ["admin", "stories", "pending"],

--- a/src/pages/admin/censor/AdminChapterModeration.tsx
+++ b/src/pages/admin/censor/AdminChapterModeration.tsx
@@ -284,6 +284,9 @@ function PendingChaptersTab() {
   const { mutate: rejectChapter } = useRejectChapter();
   const { mutate: banChapter } = useBanChapter();
   const { mutate: unbanChapter } = useUnbanChapter();
+  const [analyzingChapterId, setAnalyzingChapterId] = useState<string | null>(
+    null,
+  );
   const { mutate: analyzeChapter, isPending: isAnalyzing } =
     useTriggerAIAnalysis(() => {
       // Refetch the data table after AI analysis completes
@@ -310,7 +313,12 @@ function PendingChaptersTab() {
   };
 
   const handleAnalyze = (chapter: Chapter) => {
-    analyzeChapter(chapter._id);
+    setAnalyzingChapterId(chapter._id);
+    analyzeChapter(chapter._id, {
+      onSettled: () => {
+        setAnalyzingChapterId(null);
+      },
+    });
   };
 
   const handleBan = (chapter: Chapter) => {
@@ -422,7 +430,7 @@ function PendingChaptersTab() {
       handleApprove,
       handleReject,
       handleAnalyze,
-      isAnalyzing,
+      analyzingChapterId,
       handleViewChapterDetail,
       handleViewAIDetail,
       handleBan,
@@ -548,7 +556,7 @@ function getColumns(
   onApprove: (chapter: Chapter) => void,
   onReject: (chapter: Chapter) => void,
   onAnalyze: (chapter: Chapter) => void,
-  isAnalyzing: boolean,
+  analyzingChapterId: string | null,
   onViewChapterDetail: (chapter: Chapter) => void,
   onViewAIDetail: (chapter: Chapter) => void,
   onBan: (chapter: Chapter) => void,
@@ -619,7 +627,7 @@ function getColumns(
       id: "actions",
       header: "Hành động",
       cell: ({ row }) => (
-        <Menu shadow="md" width={200} position="bottom-end">
+        <Menu shadow="md" width={200} position="bottom-end" closeOnItemClick>
           <Menu.Target>
             <Button
               variant="light"
@@ -634,9 +642,18 @@ function getColumns(
             <Menu.Item
               leftSection={<IconBrain size={14} />}
               onClick={() => onAnalyze(row.original)}
-              disabled={isAnalyzing}
+              disabled={analyzingChapterId !== null}
             >
-              {row.original.aiAnalysis ? "Phân tích lại" : "Phân tích"}
+              {analyzingChapterId === row.original._id ? (
+                <span className="inline-flex items-center gap-2">
+                  <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-solid border-current border-r-transparent" />
+                  Đang phân tích...
+                </span>
+              ) : row.original.aiAnalysis ? (
+                "Phân tích lại"
+              ) : (
+                "Phân tích"
+              )}
             </Menu.Item>
             {row.original.aiAnalysis && (
               <Menu.Item

--- a/src/pages/admin/censor/AdminPendingStories.tsx
+++ b/src/pages/admin/censor/AdminPendingStories.tsx
@@ -48,8 +48,10 @@ export function AdminPendingStories() {
   const { mutate: rejectStory } = useRejectStory();
   const { mutate: banStory } = useBanStory();
   const { mutate: unbanStory } = useUnbanStory();
-  const { mutate: analyzeStory, isPending: isAnalyzing } = useAnalyzeStory();
+  const { mutate: analyzeStory, isPending: isAnalyzingGlobal } =
+    useAnalyzeStory();
   const [selectedStory, setSelectedStory] = useState<Story | null>(null);
+  const [analyzingStoryId, setAnalyzingStoryId] = useState<string | null>(null);
   const [detailOpened, { open: openDetail, close: closeDetail }] =
     useDisclosure(false);
   const [
@@ -68,7 +70,12 @@ export function AdminPendingStories() {
   };
 
   const handleAnalyze = (story: Story) => {
-    analyzeStory(story._id);
+    setAnalyzingStoryId(story._id);
+    analyzeStory(story._id, {
+      onSettled: () => {
+        setAnalyzingStoryId(null);
+      },
+    });
   };
 
   const handleBan = (story: Story) => {
@@ -180,11 +187,12 @@ export function AdminPendingStories() {
       handleApprove,
       handleReject,
       handleAnalyze,
-      isAnalyzing,
+      isAnalyzingGlobal,
       handleViewDetail,
       handleViewStoryDetail,
       handleBan,
       handleUnban,
+      analyzingStoryId,
     ),
     service: () => AdminCensorService.getPendingStories(true), // Enable AI analysis
     queryKey: ["pending-stories", "with-ai"],
@@ -228,6 +236,7 @@ function getColumns(
   onViewStoryDetail: (story: Story) => void,
   onBan: (story: Story) => void,
   onUnban: (story: Story) => void,
+  analyzingStoryId: string | null,
 ): ColumnDef<Story>[] {
   return [
     {
@@ -284,76 +293,89 @@ function getColumns(
     {
       id: "actions",
       header: "Hành động",
-      cell: ({ row }) => (
-        <Menu shadow="md" width={200} position="bottom-end">
-          <Menu.Target>
-            <Button
-              variant="light"
-              color="blue"
-              size="xs"
-              rightSection={<IconDotsVertical size={14} />}
-            >
-              Thao tác
-            </Button>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<IconBrain size={14} />}
-              onClick={() => onAnalyze(row.original)}
-              disabled={isAnalyzing}
-            >
-              {row.original.aiAnalysis ? "Phân tích lại" : "Phân tích"}
-            </Menu.Item>
-            {row.original.aiAnalysis && (
-              <Menu.Item
-                leftSection={<IconInfoCircle size={14} />}
-                onClick={() => onViewDetail(row.original)}
+      cell: ({ row }) => {
+        const isCurrentlyAnalyzing = analyzingStoryId === row.original._id;
+        return (
+          <Menu shadow="md" width={200} position="bottom-end" closeOnItemClick>
+            <Menu.Target>
+              <Button
+                variant="light"
+                color="blue"
+                size="xs"
+                rightSection={
+                  isCurrentlyAnalyzing ? null : <IconDotsVertical size={14} />
+                }
+                disabled={isCurrentlyAnalyzing}
               >
-                Xem phân tích
-              </Menu.Item>
-            )}
-            <Menu.Divider />
-            <Menu.Item
-              leftSection={<IconBook size={14} />}
-              onClick={() => onViewStoryDetail(row.original)}
-            >
-              Xem chi tiết
-            </Menu.Item>
-            <Menu.Item
-              leftSection={<IconCheck size={14} />}
-              onClick={() => onApprove(row.original)}
-              color="green"
-            >
-              Duyệt
-            </Menu.Item>
-            <Menu.Item
-              leftSection={<IconX size={14} />}
-              onClick={() => onReject(row.original)}
-              color="red"
-            >
-              Từ chối
-            </Menu.Item>
-            <Menu.Divider />
-            {row.original.status === "banned" ? (
+                {isCurrentlyAnalyzing ? (
+                  <span className="flex items-center gap-1">
+                    <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    Đang xử lý...
+                  </span>
+                ) : (
+                  "Thao tác"
+                )}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
               <Menu.Item
-                leftSection={<IconLockOff size={14} />}
-                onClick={() => onUnban(row.original)}
+                leftSection={<IconBrain size={14} />}
+                onClick={() => onAnalyze(row.original)}
+                disabled={isAnalyzing}
+              >
+                {row.original.aiAnalysis ? "Phân tích lại" : "Phân tích"}
+              </Menu.Item>
+              {row.original.aiAnalysis && (
+                <Menu.Item
+                  leftSection={<IconInfoCircle size={14} />}
+                  onClick={() => onViewDetail(row.original)}
+                >
+                  Xem phân tích
+                </Menu.Item>
+              )}
+              <Menu.Divider />
+              <Menu.Item
+                leftSection={<IconBook size={14} />}
+                onClick={() => onViewStoryDetail(row.original)}
+              >
+                Xem chi tiết
+              </Menu.Item>
+              <Menu.Item
+                leftSection={<IconCheck size={14} />}
+                onClick={() => onApprove(row.original)}
                 color="green"
               >
-                Mở khóa
+                Duyệt
               </Menu.Item>
-            ) : (
               <Menu.Item
-                leftSection={<IconLock size={14} />}
-                onClick={() => onBan(row.original)}
-                color="orange"
+                leftSection={<IconX size={14} />}
+                onClick={() => onReject(row.original)}
+                color="red"
               >
-                Khóa
+                Từ chối
               </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
-      ),
+              <Menu.Divider />
+              {row.original.status === "banned" ? (
+                <Menu.Item
+                  leftSection={<IconLockOff size={14} />}
+                  onClick={() => onUnban(row.original)}
+                  color="green"
+                >
+                  Mở khóa
+                </Menu.Item>
+              ) : (
+                <Menu.Item
+                  leftSection={<IconLock size={14} />}
+                  onClick={() => onBan(row.original)}
+                  color="orange"
+                >
+                  Khóa
+                </Menu.Item>
+              )}
+            </Menu.Dropdown>
+          </Menu>
+        );
+      },
     },
   ];
 }

--- a/src/services/AdminCensorService.ts
+++ b/src/services/AdminCensorService.ts
@@ -61,7 +61,7 @@ export const AdminCensorService = {
     id: string,
   ): Promise<{
     story: Story;
-    analysis: AIAnalysis;
+    analysis: AIAnalysis & { error?: string };
   }> => {
     const response = await axios.post(`/admin/stories/${id}/analyze`);
     return response.data.data;


### PR DESCRIPTION
- Enhanced admin content moderation to show individual loading state per chapter/story instead of global loading
- Added error handling to display AI analysis errors as notifications
- Updated AdminCensorService type to include error field in analysis response
- UI now shows spinner and "Đang phân tích..." text for the specific item being analyzed