### PR TITLE
Improve reading lists, story card, and save flow

### DIFF
--- a/src/components/author/ReadingListTab.tsx
+++ b/src/components/author/ReadingListTab.tsx
@@ -23,6 +23,7 @@ import { Plus, Edit, Trash2, MoreVertical } from "lucide-react";
 import { useUserStore } from "../../stores/useUserStore";
 import {
   useMyReadingLists,
+  usePublicReadingLists,
   useCreateReadingList,
   useUpdateReadingList,
   useDeleteReadingList,
@@ -49,7 +50,13 @@ export function ReadingListTab() {
     string | null
   >(null);
 
-  const { data: readingLists = [], isLoading } = useMyReadingLists();
+  const isOwnProfile = authorId === user?._id;
+  const myListsQuery = useMyReadingLists();
+  const publicListsQuery = usePublicReadingLists(isOwnProfile ? "" : authorId!);
+
+  const { data: readingLists = [], isLoading } = isOwnProfile
+    ? myListsQuery
+    : publicListsQuery;
   const createMutation = useCreateReadingList();
   const updateMutation = useUpdateReadingList();
   const deleteMutation = useDeleteReadingList();
@@ -147,33 +154,35 @@ export function ReadingListTab() {
               {readingLists.length} danh sách
             </Text>
           </div>
-          { authorId === user?._id &&
-          <Button
-            leftSection={<Plus size={18} />}
-            onClick={handleOpenCreateModal}
-            className="bg-blue-600 hover:bg-blue-700"
-          >
-            Tạo danh sách
-          </Button>}
+          {authorId === user?._id && (
+            <Button
+              leftSection={<Plus size={18} />}
+              onClick={handleOpenCreateModal}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              Tạo danh sách
+            </Button>
+          )}
         </Group>
 
         {/* Reading Lists - Wattpad Style */}
         {readingLists.length === 0 ? (
           <Paper withBorder radius="md" p="xl">
             <Center py="xl">
-              {authorId === user?._id ? 
-              (<Stack align="center" gap="md">
-                <Text c="dimmed" size="lg">
-                  Bạn chưa có danh sách đọc nào
-                </Text>
-                <Button
-                  variant="light"
-                  leftSection={<Plus size={16} />}
-                  onClick={handleOpenCreateModal}
-                >
-                  Tạo danh sách đầu tiên
-                </Button>
-              </Stack>): (
+              {authorId === user?._id ? (
+                <Stack align="center" gap="md">
+                  <Text c="dimmed" size="lg">
+                    Bạn chưa có danh sách đọc nào
+                  </Text>
+                  <Button
+                    variant="light"
+                    leftSection={<Plus size={16} />}
+                    onClick={handleOpenCreateModal}
+                  >
+                    Tạo danh sách đầu tiên
+                  </Button>
+                </Stack>
+              ) : (
                 <Text c="dimmed" size="lg">
                   Tác giả này chưa có danh sách đọc nào
                 </Text>

--- a/src/components/story/AuthorStoryCard.tsx
+++ b/src/components/story/AuthorStoryCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, Image, Stack, Text, Group, Badge } from "@mantine/core";
+import { Card, Flex, Image, Stack, Text, Group } from "@mantine/core";
 import { Eye, Heart, List, Star } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -29,31 +29,19 @@ export default function AuthorStoryCard({ story }: AuthorStoryCardProps) {
     >
       <Flex gap="md">
         {/* Cover */}
-        <Image
-          src={story.image}
-          w={90}
-          h={120}
-          radius="md"
-          fit="cover"
-        />
+        <Image src={story.image} w={90} h={120} radius="md" fit="cover" />
 
         {/* Content */}
         <Stack gap={6} style={{ flex: 1 }}>
-          <Flex justify="space-between" align="center">
-            <Text
-              component={Link}
-              to={`/story/${story.slug}`}
-              fw={600}
-              size="lg"
-              className="hover:text-blue-600"
-            >
-              {story.title}
-            </Text>
-
-            <Badge color={story.isFinish ? "green" : "blue"}>
-              {story.isFinish ? "Hoàn thành" : "Đang ra"}
-            </Badge>
-          </Flex>
+          <Text
+            component={Link}
+            to={`/story/${story.slug}`}
+            fw={600}
+            size="lg"
+            className="hover:text-blue-600"
+          >
+            {story.title}
+          </Text>
 
           {/* Stats */}
           <Group gap="lg">
@@ -74,11 +62,7 @@ export default function AuthorStoryCard({ story }: AuthorStoryCardProps) {
           </Group>
 
           {/* Description */}
-          <Text
-            size="sm"
-            c="dimmed"
-            lineClamp={3}
-          >
+          <Text size="sm" c="dimmed" lineClamp={3}>
             {story.description}
           </Text>
         </Stack>

--- a/src/pages/author/WriteChapterPage.tsx
+++ b/src/pages/author/WriteChapterPage.tsx
@@ -167,7 +167,6 @@ export default function WriteChapterPage() {
         chapterNumber: ch.chapterNumber,
       });
       setContentError(undefined);
-      setSaved(false);
       setChapterListOpened(false);
 
       // Fetch chapter content from the server
@@ -176,9 +175,17 @@ export default function WriteChapterPage() {
         const html = fullChapter.contentURL ?? "";
         setEditorInitialContent(html);
         setContentPayload({ mode: "editor", html });
+
+        // Update refs to track saved state
+        lastSavedContentRef.current = html;
+        lastSavedTitleRef.current = ch.title;
+        lastSavedChapterTypeRef.current = ch.isPremium ? "vip" : "free";
+        setHasChangesAfterSave(false);
+        setSaved(true);
       } catch {
         setEditorInitialContent("");
         setContentPayload(null);
+        setSaved(false);
       }
     },
     [chapters, form],
@@ -227,7 +234,12 @@ export default function WriteChapterPage() {
               ? 1
               : Math.max(...chapterList.map((c) => c.chapterNumber)) + 1;
           const newTitle = `Chương ${nextNum}`;
-          form.setValues({ title: newTitle, chapterType: "free", price: 1, chapterNumber: nextNum });
+          form.setValues({
+            title: newTitle,
+            chapterType: "free",
+            price: 1,
+            chapterNumber: nextNum,
+          });
           return;
         }
 
@@ -249,7 +261,6 @@ export default function WriteChapterPage() {
           chapterNumber: ch.chapterNumber,
         });
         setContentError(undefined);
-        setSaved(true);
         setChapterListOpened(false);
 
         // Fetch chapter content from the server
@@ -258,9 +269,17 @@ export default function WriteChapterPage() {
           const html = fullChapter.contentURL ?? "";
           setEditorInitialContent(html);
           setContentPayload({ mode: "editor", html });
+
+          // Update refs to track saved state
+          lastSavedContentRef.current = html;
+          lastSavedTitleRef.current = ch.title;
+          lastSavedChapterTypeRef.current = ch.isPremium ? "vip" : "free";
+          setHasChangesAfterSave(false);
+          setSaved(true);
         } catch {
           setEditorInitialContent("");
           setContentPayload(null);
+          setSaved(false);
         }
       })
       .catch(() => {
@@ -346,7 +365,12 @@ export default function WriteChapterPage() {
 
     // Pre-fill UI immediately for instant feedback
     setSelectedChapterIndex(null);
-    form.setValues({ title: newTitle, chapterType: "free", price: 1, chapterNumber: newNum });
+    form.setValues({
+      title: newTitle,
+      chapterType: "free",
+      price: 1,
+      chapterNumber: newNum,
+    });
     setEditorInitialContent("");
     setEditorResetKey((k) => k + 1);
     setContentPayload(null);
@@ -395,7 +419,7 @@ export default function WriteChapterPage() {
       (c) =>
         c.chapterNumber === values.chapterNumber &&
         (selectedChapterIndex === null ||
-          chapters[selectedChapterIndex].id !== c.id)
+          chapters[selectedChapterIndex].id !== c.id),
     );
     if (isDuplicate) {
       setChapterError("Chương số đã tồn tại. Vui lòng chọn số khác.");
@@ -459,7 +483,7 @@ export default function WriteChapterPage() {
     try {
       if (selectedChapterIndex !== null) {
         // Update existing chapter
-        
+
         const chapterId = chapters[selectedChapterIndex].id;
         await AuthorService.updateChapter(chapterId, formData);
       } else {
@@ -491,8 +515,8 @@ export default function WriteChapterPage() {
   };
 
   const handlePublishClick = async () => {
-    // Check if there are unsaved changes after last save
-    if (hasChangesAfterSave) {
+    // Check if content is empty or unsaved at all
+    if (!saved || hasChangesAfterSave) {
       setUnsavedPublishModalOpened(true);
       return;
     }
@@ -931,14 +955,18 @@ export default function WriteChapterPage() {
       <Container size="md" py="xl">
         <form onSubmit={(e) => e.preventDefault()}>
           <Stack gap="lg">
-            <NumberInput 
+            <NumberInput
               label="Chương số"
               ref={chapterNumberInputRef}
               size="md"
               withAsterisk
               {...form.getInputProps("chapterNumber")}
               error={chapterError}
-              placeholder={selectedChapterIndex !== null ? (chapters[selectedChapterIndex].chapterNumber).toString() : (nextChapterNumber-1).toString()}
+              placeholder={
+                selectedChapterIndex !== null
+                  ? chapters[selectedChapterIndex].chapterNumber.toString()
+                  : (nextChapterNumber - 1).toString()
+              }
             />
             {/* Chapter title input - centered, clean */}
             <TextInput
@@ -951,7 +979,7 @@ export default function WriteChapterPage() {
               styles={{
                 input: {
                   fontWeight: 500,
-                  color: "var(--mantine-color-text)"
+                  color: "var(--mantine-color-text)",
                 },
               }}
               {...form.getInputProps("title")}
@@ -959,22 +987,24 @@ export default function WriteChapterPage() {
 
             {/* Chapter content editor */}
             <Box>
-            <Text size="md" fw={500} >Nội dung<span className="text-red-500 ml-1">*</span></Text>
-            <Box
-              className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
-              p="md"
-            >
-              <ChapterContentInput
-                key={editorResetKey}
-                onChange={(payload) => {
-                  setContentPayload(payload);
-                  if (payload) setContentError(undefined);
-                  setSaved(false);
-                }}
-                initialContent={editorInitialContent}
-                error={contentError}
-              />
-            </Box>
+              <Text size="md" fw={500}>
+                Nội dung<span className="text-red-500 ml-1">*</span>
+              </Text>
+              <Box
+                className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+                p="md"
+              >
+                <ChapterContentInput
+                  key={editorResetKey}
+                  onChange={(payload) => {
+                    setContentPayload(payload);
+                    if (payload) setContentError(undefined);
+                    setSaved(false);
+                  }}
+                  initialContent={editorInitialContent}
+                  error={contentError}
+                />
+              </Box>
             </Box>
 
             {/* Word count warning below editor */}
@@ -1066,6 +1096,8 @@ export default function WriteChapterPage() {
               onClick={async () => {
                 setUnsavedPublishModalOpened(false);
                 await handleSave();
+                // Auto-proceed with publish after save completes
+                await proceedWithPublish();
               }}
             >
               Lưu và tiếp tục


### PR DESCRIPTION
ReadingListTab: add usePublicReadingLists and select public vs. own lists based on profile; make create-button and empty-state UI conditional for owner; minor JSX formatting fixes.

AuthorStoryCard: remove status Badge and unused import, simplify markup and formatting for tighter layout.

WriteChapterPage: strengthen saved-state tracking by updating lastSaved refs and setHasChangesAfterSave when loading chapter content, unify setSaved handling on success/error, change publish guard to require saved state (not just changes flag), auto-proceed with publish after saving, and small form/placeholder/formatting cleanups for inputs and editor component.