### PR TITLE
fix(admin): handle topic type in story detail modal

### DIFF
--- a/src/pages/admin/censor/AdminStoryModeration.tsx
+++ b/src/pages/admin/censor/AdminStoryModeration.tsx
@@ -110,11 +110,14 @@ export function StoryDetailModal({
               Thể loại
             </Text>
             <Group gap={4}>
-              {story.topics.map((t) => (
-                <Badge key={t} size="xs" variant="light">
-                  {t}
-                </Badge>
-              ))}
+              {story.topics.map((t) => {
+                const name = typeof t === "string" ? t : t?.name;
+                return (
+                  <Badge key={name} size="xs" variant="light">
+                    {name}
+                  </Badge>
+                );
+              })}
             </Group>
             <Text size="sm" c="dimmed" mt={4}>
               Ngày gửi


### PR DESCRIPTION
Some stories store topics as objects with a name property. The modal previously tried to render the raw object, causing errors. Updated the mapping logic to extract the name or use the string directly, ensuring consistent badge display.